### PR TITLE
Translate Hebrew dictionary files to English

### DIFF
--- a/hebrew/translated/Context-Free Functions_dictionary_heb.txt
+++ b/hebrew/translated/Context-Free Functions_dictionary_heb.txt
@@ -1,0 +1,862 @@
+1
+Not
+2
+Returns "true" if the boolean parameter is "false", and "false" if the boolean parameter is "true".
+3
+Boolean
+4
+Integer Equals
+5
+Returns "true" if the two integer parameters are equal.
+6
+Integer 1
+7
+Integer 2
+8
+Integer Greater Than
+9
+Returns "true" if Integer 1 is greater than Integer 2.
+10
+Integer Less Than
+11
+Returns "true" if Integer 1 is less than Integer 2.
+12
+Integer Maximum
+13
+Returns the maximum of Integer 1 and Integer 2.
+14
+Integer Minimum
+15
+Returns the minimum of Integer 1 and Integer 2.
+16
+Integer Addition
+17
+Returns (Integer 1 + Integer 2), i.e. the result of adding Integer 2 and Integer 1.
+18
+Integer Subtraction
+19
+Returns (Integer 1 - Integer 2), i.e. the result of subtracting Integer 2 from Integer 1.
+20
+Integer Multiplication
+21
+Returns the result of multiplying Integer parameter 1 by Integer parameter 2 (i.e. Integer 1 * Integer 2).
+22
+Integer Division
+23
+Returns the result of dividing Integer parameter 1 by Integer parameter 2 (i.e. Integer 1 / Integer 2). If Integer 2 is zero - a null integer is returned.
+24
+Random Integer
+25
+Returns a random integer in the range between 0 and some large positive number (implementation dependent) - accessible via the RandomIntegerMax function.
+26
+Random Integer Maximum
+27
+Returns the highest integer that can be returned by the RandomInteger function.
+28
+Null Integer
+29
+Returns a null integer, which is a non-existent integer. Used to denote a "missing" integer value.
+30
+Null Real Number
+31
+Returns a null real number, which is a non-existent real number. Used to denote a "missing" real number value.
+32
+Real Number Equals
+33
+Returns "true" if the two real number parameters are equal.
+34
+Real Number 1
+35
+Real Number 2
+36
+Real Number Greater Than
+37
+Returns "true" if Real Number 1 is greater than Real Number 2.
+38
+Real Number Less Than
+39
+Returns "true" if Real Number 1 is less than Real Number 2.
+40
+Real Number Addition
+41
+Returns the result of adding Real Number parameter 1 to Real Number parameter 2 (i.e. Real Number 1 + Real Number 2).
+42
+Real Number Division
+43
+Returns the result of dividing Real Number parameter 1 by Real Number parameter 2 (i.e. Real Number 1 / Real Number 2). If Real Number 2 is zero - a null real number is returned.
+44
+Real Number Multiplication
+45
+Returns the result of multiplying Real Number parameter 1 by Real Number parameter 2 (i.e. Real Number 1 * Real Number 2).
+46
+Real Number Power
+47
+Returns the result of raising the specified base to the power of the specified exponent.
+48
+Base
+49
+Exponent
+50
+String Equals
+51
+Returns "true" if the two string parameters are equal.
+52
+String 1
+53
+String 2
+54
+String Concatenation
+55
+Returns a string that is the result of concatenating String 2 (parameter) to the end of String 1 (parameter).
+56
+Word in String
+57
+Returns a word (substring) from the specified parsed string. A word is a sequence of characters (possibly empty) separated by the specified separator character and/or by the start/end of the string. The index (1-based) of the required word is specified by WordIndex. For example: given that the separator is "," (comma), the parsed string "F 16,B-52 ,,,G8" contains 5 words. Word 2 is "B-52 " and Word 4 is "" (empty string). Note: if the separator contains more or less than one character or if WordIndex is greater than the number of words in the parsed string - an exception is thrown.
+58
+Parsed String
+59
+Separator
+60
+Word Index
+61
+Character Index in String
+62
+Returns the index (1-based) in the specified string of the first character that appears in the specified search characters string. If the specified string does not contain any of the characters of the specified search characters - a null integer is returned.
+63
+String
+64
+Search Characters
+65
+Character Count in String
+66
+Returns the number of characters in the specified string that appear in the specified search characters string. Examples: CharCountInString("ABC ABC DEF", "AE") = 3 CharCountInString("ABC ABC DEF", "GB") = 2 CharCountInString("ABC ABC DEF", "M") = 0
+67
+Exceptional Character Index in String
+68
+Returns the index (1-based) in the specified string of the first character that does not appear in the specified search characters string. If no such character is found - a null integer is returned.
+69
+Substring
+70
+Returns a part of the specified string that starts at the specified start index (1-based) and extends for the specified length number of characters or until the end of the specified string - whichever comes first. Examples: - SubString("ABCDEF", 4, 10) = "DEF" - SubString("ABCDEF", 1, 0) = "" (empty string)
+71
+Start Index
+72
+Length
+73
+String Length
+74
+Returns the number of characters in the specified string.
+75
+Time Equals
+76
+Returns "true" if the two time parameters are equal.
+77
+Time 1
+78
+Time 2
+79
+Time Greater Than
+80
+Returns "true" if Time 1 is greater than Time 2.
+81
+Time Addition
+82
+Returns the result of adding the TimeSpan parameter to the Time parameter.
+83
+Time
+84
+Time Span
+85
+Time Subtraction
+86
+Returns the result of subtracting the TimeSpan parameter from the Time parameter.
+87
+Null Time
+88
+Returns a null time, which is a non-existent time. Used to denote a "missing" time value.
+89
+Time Span Equals
+90
+Returns True if the two TimeSpan parameters are equal.
+91
+Time Span 1
+92
+Time Span 2
+93
+Null Time Span
+94
+Returns a null time span, which is a non-existent time span. Used to denote a "missing" time span value.
+95
+Time Span
+96
+Returns a time span equivalent to the duration (parameter) in seconds. (e.g. Timespan(85) = 00:00:01:25)
+97
+Duration
+98
+Time Span Greater Than
+99
+Returns "true" if Time Span 1 is greater than Time Span 2.
+100
+Time Span 1
+101
+Time Span 2
+102
+Time Difference
+103
+Returns the absolute difference between Time 1 and Time 2. Note: TimeDifference(T1,T2) = TimeDifference(T2,T1) by definition.
+104
+Hour
+105
+Returns the hour part (hh) of the specified time value, which is a value in the range 0-23.
+106
+Minute
+107
+Returns the minute part (mm) of the specified time value, which is a value in the range 0-59.
+108
+Second
+109
+Returns the second part (ss) of the specified time value, which is a value in the range 0-59.
+110
+Enumeration Equals
+111
+Returns "true" if the two enumeration parameters are equal.
+112
+Enumeration 1
+113
+Enumeration 2
+114
+Is Kind Of
+115
+Returns "true" if Enumeration 1 (parameter) is a sub-type of (i.e. belongs to the enumeration hierarchy defined by) Enumeration 2 (parameter). Note: IsKindOf(E,E) is "true" for any enumeration E by definition.
+116
+Null Enumeration
+117
+Returns a null enumeration, which is a non-existent enumeration. Used to denote a "missing" enumeration value.
+118
+Enumeration Children Count
+119
+Returns the number of child enumerations under the specified enumeration.
+120
+Enumeration
+121
+Sequence Under Parent
+122
+Returns the sequence number of the child (1-based) of the specified enumeration under its parent enumeration. If the specified enumeration has no parent enumeration - a null integer is returned.
+123
+Enumeration By Sequence Under Parent
+124
+Returns the child enumeration of the specified parent enumeration whose sequence under the parent is the specified sequence. Example: EnumerationBySequenceUnderParent(ES_ExecutionState, 2) = ES_Skipped. If the specified parent enumeration has no child enumeration with the specified sequence - a null enumeration is returned.
+125
+Parent Enumeration
+126
+Sequence
+127
+External ID of Enumeration
+128
+Returns the external ID associated with the specified enumeration value. Note: external IDs are used to map enumeration values to equivalent enumeration types (AKA Native Types) of the host simulation.
+129
+Display Name of Enumeration
+130
+Returns the display name associated with the specified enumeration value.
+131
+Convert to Yes/No
+132
+Converts the received YesNo parameter as a root enumeration (not specific), to a YN_YesNo value (leaf). If the received parameter is not a leaf value of YN_YesNo - an InvalidDowncast exception is thrown.
+133
+Yes/No
+134
+Enumeration by External ID
+135
+Returns the enumeration value whose external ID is the specified external ID. If no such enumeration exists - a null enumeration is returned.
+136
+External ID
+137
+Sector
+138
+Returns a sector whose middle azimuth is the specified direction and whose width is defined by the specified angle.
+139
+Direction
+140
+Angle
+141
+The width of the returned sector.
+142
+Azimuth of Line
+143
+Returns the azimuth of the line parameter (from the first point to the second point).
+144
+Line
+145
+Opposite Azimuth
+146
+Returns the opposite azimuth (opposite direction) of the given azimuth parameter.
+147
+Azimuth
+148
+Azimuth Addition
+149
+Returns the sum of Azimuth 1 and Azimuth 2 parameters. Note: Azimuth is cyclical in nature, for example Azimuth(150)+Azimuth(300) = Azimuth(90).
+150
+Azimuth 1
+151
+Azimuth 2
+152
+Returns an azimuth based on the integer parameter. Note: the integer parameter can be negative and greater than 359. For example: Azimuth(-20) = Azimuth(340), Azimuth(1000) = Azimuth(280).
+153
+Integer
+154
+Azimuth Subtraction
+155
+Returns the difference between Azimuth 1 and Azimuth 2 parameters. Note: Azimuth is cyclical in nature, for example Azimuth(150)-Azimuth(300) = Azimuth(-150) = Azimuth(210).
+156
+Null Azimuth
+157
+Returns a null azimuth, which is a non-existent azimuth. Used to denote a "missing" azimuth value.
+158
+Point Equals
+159
+Returns "true" if Point 1 and Point 2 (parameters) are equal.
+160
+Point 1
+161
+Point 2
+162
+Null Point
+163
+Returns a null point, which is a non-existent point. Used to denote a "missing" point value.
+164
+Point Name
+165
+Returns the name of the specified point.
+166
+Point
+167
+Point with Name
+168
+Returns a point based on the specified point and having the specified name as its name.
+169
+Name
+170
+Point on Azimuth
+171
+Returns a point located at the specified distance (parameter) from the source parameter, and at the specified azimuth (parameter) from the source parameter.
+172
+Source
+173
+Distance
+174
+Distance in meters from the source point.
+175
+Azimuth from the source point.
+176
+Returns the line defined by the two point arguments.
+177
+Null Line
+178
+Returns a null line, which is a non-existent line (composed of two null points). Used to denote a "missing" line value.
+179
+Line Equals
+180
+Returns "true" if Line 1 and Line 2 (parameters) are equal.
+181
+Line 1
+182
+Line 2
+183
+Left Perpendicular Line
+184
+Returns a line that is perpendicular to the line parameter and has the same length. The first point of the returned line is the second point of the line parameter, and its second point is to the left of the line parameter.
+185
+Right Perpendicular Line
+186
+Returns a line that is perpendicular to the line parameter and has the same length. The first point of the returned line is the second point of the line parameter, and its second point is to the right of the line parameter.
+187
+Line Length
+188
+Returns the length (in meters) of the input line parameter.
+189
+Point on Line
+190
+Returns a point on the line parameter whose distance from the first point of the line is OffsetPercent (0..100) of the line length.
+191
+Offset Percent
+192
+Is Point on Right Side
+193
+Returns true if the point parameter is on the right side of the line parameter. Left and right are determined relative to the direction of the line (from its first point to its second point).
+194
+Reversed Line
+195
+Returns a line containing the points of the line parameter in reverse order.
+196
+Polyline Length
+197
+Returns the length (in meters) of the input polyline parameter.
+198
+Polyline
+199
+Polyline Name
+200
+Returns the name of the specified polyline.
+201
+Number of Points in Polyline
+202
+Returns the number of points (vertices) of the specified polyline.
+203
+Point in Polyline
+204
+Returns the point (vertex) of the specified polygon, corresponding to the specified index (1-based). If the specified index is less than one or greater than the number of points in the specified polyline - an exception is thrown.
+205
+Index
+206
+Last Point in Polyline
+207
+Returns the last point of the polyline parameter.
+208
+Farthest Point in Polyline
+209
+Returns the point on the specified polyline that is farthest from the specified point.
+210
+Snap to Polyline
+211
+Returns the point on the specified polyline parameter that is closest (geometrically) to the specified point parameter.
+212
+Trimmed Polyline
+213
+Returns a polyline that is the middle part of the input polyline parameter. The TrimFromStart and TrimFromEnd parameters specify the length (in meters) to be trimmed from each side of the input polyline. Note that when the sum of TrimFromStart+TrimFromEnd is greater than the length of the input polyline, the returned polyline is empty (has no points).
+214
+The input polyline.
+215
+Trim From Start
+216
+The distance (in meters) to be trimmed from the start of the polyline.
+217
+Trim From End
+218
+The distance (in meters) to be trimmed from the end of the polyline.
+219
+Trim Polyline Between Points
+220
+Returns the middle part of a specified polyline (parameter), which starts at the specified StartPoint parameter - snapped to the specified polyline, and ends at the specified EndPoint parameter - also snapped to the specified polyline.
+221
+Start Point
+222
+End Point
+223
+Polyline with Trimmed Loops
+224
+Returns a polyline based on the specified polyline, with loops trimmed/removed. A loop is a self-intersecting section of a polyline that starts and ends at the same [self-intersection] point.
+225
+Reverse Polyline
+226
+Returns a polyline containing the points of the polyline parameter in reverse order.
+227
+Parallel Polyline
+228
+Returns a polyline parallel to the specified polyline, at the specified distance from it - to the right (positive offset value) or to the left (negative offset value). The returned polyline does not intersect itself, i.e. "loops" that may be created in the process of its creation are all trimmed. Since the returned polyline may contain arcs, the resolution for their approximation is defined by CircleNumberOfPoints, e.g. CircleNumberOfPoints = 60 means that a 90-degree arc should be approximated by 15 points.
+229
+Offset
+230
+Number of Points in Circle
+231
+Add to Polyline
+232
+Returns a polyline created by joining Polyline1 and Polyline2 (parameters). The returned polyline consists of all the points of Polyline1, followed by all the points of Polyline2. If the first point of Polyline2 is identical to the last point of Polyline1 - it is omitted from the returned polyline to prevent redundancy.
+233
+Polyline 1
+234
+Polyline 2
+235
+Null Polyline
+236
+Returns a null polyline, which is a non-existent polyline. Used to designate a "missing" polyline value.
+237
+Polyline Equals
+238
+Returns "true" if Polyline1 and Polyline2 (parameters) are equal.
+239
+Polyline 1
+240
+Polyline 2
+241
+Edge of Polyline
+242
+Returns the edge of the specified polyline on which the specified point is located (snapped to the polyline). Note: an edge of a polyline is a line connecting two adjacent vertices.
+243
+Polygon Equals
+244
+Returns "true" if Polygon1 and Polygon2 (parameters) are equal.
+245
+Polygon 1
+246
+Polygon 2
+247
+Null Polygon
+248
+Returns a null polygon.
+249
+Polygon Name
+250
+Returns the name of the specified polygon.
+251
+Polygon
+252
+Polygon with Name
+253
+Returns a polygon based on the given polygon and having the given name as its name.
+254
+Left Part of Polygon
+255
+Returns a polygon that is the part of the given polygon (parameter) located in the left part of the plane - as divided by the DividerLine parameter. Left and right are relative to the direction of the DividerLine - from its first point to its second point. If the entire polygon is in the right part of the divided plane - a null polygon is returned.
+256
+Divider Line
+257
+Rectangle
+258
+Returns a rectangular polygon. The center of the rectangle is specified by the Center parameter. The Width and Depth parameters specify the dimensions of the rectangle's sides. The rectangle is aligned so that its width side faces the direction azimuth parameter (i.e., the depth side is parallel to the direction azimuth).
+259
+Center
+260
+Width
+261
+The width (in meters) of the rectangle.
+262
+Depth
+263
+The depth (in meters) of the rectangle.
+264
+Direction
+265
+The azimuth of the depth dimension.
+266
+Right Part of Polygon
+267
+Returns a polygon that is the part of the given polygon (parameter) located in the right part of the plane - as divided by the DividerLine parameter. Left and right are relative to the direction of the DividerLine - from its first point to its second point. If the entire polygon is in the left part of the divided plane - a null polygon is returned.
+268
+Add to Polygon
+269
+Returns a polygon that is the union of two polygons. If the two polygons do not overlap at all - the result is obtained by adding a zero-width "bridge" connecting the two polygons between two vertices - to create the union polygon. The location of the "bridge" is chosen so that it does not intersect either of the two polygons. For example: if Polygon1 is a triangle A1,B1,C1 and Polygon2 is a triangle A2,B2,C2 and the polygons do not overlap at all and the line B1-C2 is the first connecting line between vertices that does not intersect either of the two polygons, the returned polygon is B1,C1,A1,B1,C2,A2,B2,C2 (where C2-B1 is naturally the last closing edge of the polygon). Note: for this purpose, tangent polygons are considered partially overlapping, i.e. no "bridge" is needed to connect them.
+270
+Polygon 1
+271
+Polygon 2
+272
+Triangle
+273
+Returns a triangular polygon based on the three vertex parameters.
+274
+Vertex 1
+275
+Vertex 2
+276
+Vertex 3
+277
+Polygon Center
+278
+Returns the point that is the center of gravity of the specified polygon parameter. Note that the center point of the returned polygon can be outside the specified polygon.
+279
+Polygon Area
+280
+Returns the area of the specified polygon, in square kilometers.
+281
+Point in Polygon
+282
+Returns "true" if the specified point is inside the specified polygon (parameters). For this purpose, all points located on the perimeter of the polygon are considered inside the polygon.
+283
+Subtract from Polygon
+284
+Returns a polygon that is the result of subtracting Polygon2 from Polygon1. If Polygon2 completely covers Polygon1 - a null polygon is returned. If the subtraction yields more than one polygon - the one with the largest area is returned (see PolygonArea).
+285
+Longest Crossing Line of Polygon
+286
+Returns the longest line that crosses the specified polygon (hereinafter P) and is entirely within it, i.e. the longest line L that satisfies the following conditions:
+- The two endpoints of L are located on the perimeter of P.
+- All other points of L are "truly inside" P, i.e. are inside P but not on the perimeter of P.
+Note: The following possible implementation is slightly inaccurate but is considered good enough:
+- Edge N points at equal intervals (p1,p2...pN) on the perimeter of P, where N is chosen according to performance constraints (e.g. N = 15).
+- Check every possible line between points pi and pj (i != j) to see if it is truly inside P.
+- Return the longest of all lines found to be truly inside P.
+287
+Polyline Contained in Polygon
+288
+Returns a polyline based on the specified polyline, where external segments (segments that pass outside the specified polygon) are replaced by perimeter segments of the polygon. The returned polyline is therefore fully contained within the polygon. For this purpose, all points on the perimeter of the specified polygon are considered to be inside it. The specified polyline should start and end inside the specified polygon. If this is not the case - a null polyline is returned. An external segment of the specified polyline is a segment that starts at point Ps - where the polyline exits the polygon, and ends at point Pe - where the polyline re-enters the polygon. Each external segment is replaced by a perimeter segment of the polygon Ps...Pe which is the shorter of the two (forward/backward along the polygon's perimeter).
+289
+Ellipse Center
+290
+Returns the center of the ellipse.
+291
+Ellipse
+292
+Ellipse Diameter
+293
+Returns the diameter (line) of the specified ellipse (parameter) at the specified azimuth (parameter). A diameter is a line that crosses the center of the ellipse and its two points are on the perimeter of the ellipse. The azimuth of the returned diameter line (from its first point to its second point) is specified by the azimuth parameter.
+294
+Shortest Diameter of Ellipse
+295
+Returns the shortest diameter (line) of the specified ellipse (parameter). A diameter is a line that crosses the center of the ellipse and its two points are on the perimeter of the ellipse. The order of the two points in the returned line is arbitrary.
+296
+Ellipse Bounding Polygon
+297
+Returns the smallest ellipse that bounds the specified polygon parameter. If the specified polygon is a null polygon - a null ellipse is returned.
+298
+Returns an ellipse based on the specified width, depth, center and direction (parameters). The direction of the ellipse is the azimuth of the specified depth dimension.
+299
+The width (in meters) of the ellipse.
+300
+The depth (in meters) of the ellipse.
+301
+Ellipse Equals
+302
+Returns True if the two ellipse parameters are equal.
+303
+Ellipse 1
+304
+Ellipse 2
+305
+Null Ellipse
+306
+Returns a null ellipse, which is a non-existent ellipse. Used to designate a "missing" ellipse value.
+307
+Intersection Point
+308
+Returns the intersection point of Line1 parameter and Line2 parameter. The two line parameters are considered infinite, i.e. the intersection point does not have to be on either of them. If the two lines are parallel, a null point is returned.
+309
+Polygon Crossing Point
+310
+Returns the first point at which the line parameter crosses (intersects) the polygon parameter, when advancing from the first point of the line parameter towards its second point. If the line and the polygon do not intersect, a null point is returned.
+311
+Intersection Point of Polyline and Ellipse
+312
+Returns the first intersection point between the polyline (parameter) and the ellipse (parameter). The search advances along the polyline parameter, starting from its first point. If the polyline and the ellipse do not intersect, a null point is returned.
+313
+Intersection Point of Polylines
+314
+Returns the first point along the first polyline that is intersected by the second polyline. If the two polylines do not intersect, a null point is returned.
+315
+The second polyline.
+316
+Intersection Percentage of Polyline and Circle
+317
+Returns the percentage (0-100) of the specified polyline that passes inside a circle defined by the specified center and radius.
+Note: Since the polyline may enter and exit the circle multiple times, an accurate geometric calculation is not trivial. The following alternative calculation method is considered a valid approximation:
+- The result is based on sampling N points at equal intervals along the polyline, where N is relatively small (e.g. 25).
+- Given that the length of the polyline is L, the distance between the points is L/(N-1) because the first and last points of the polyline are of course included in the sample.
+- The result is 100*I/N where I is the number of sampled points that are inside the circle (i.e., whose distance from the specified center is not greater than the specified radius).
+318
+Radius
+319
+Polygon Intersection
+320
+Returns the area common to both Polygon1 and Polygon2. If Polygon1 and Polygon2 do not intersect - EmptyPolygon is returned.
+321
+Null Unit
+322
+Returns a null unit, which is a non-existent unit. Used to designate a "missing" unit value.
+323
+Unit Equals
+324
+Returns "true" if Unit1 and Unit2 (parameters) are the same unit.
+325
+Unit 1
+326
+Unit 2
+327
+Null Unit Collection
+328
+Returns an empty unit collection.
+329
+Unit as Collection
+330
+Returns a unit collection containing the specified unit parameter.
+331
+Unit
+332
+Unit Collection Count
+333
+Returns the number of units in the specified unit collection parameter.
+334
+Unit Collection
+335
+Unit in Collection
+336
+Returns a unit of the specified collection parameter corresponding to the specified index parameter (1-based). If the specified index is out of the collection's bounds - an exception is thrown.
+337
+Collection
+338
+Unit Index in Collection
+339
+Returns the index (1-based) of the first occurrence of the specified unit in the specified collection. If the specified unit does not appear in the specified collection - NullInteger is returned.
+340
+Add Units to Collection
+341
+Returns a collection containing all the units of the specified UnitCollection1 followed by all the units of the specified UnitCollection2.
+342
+Unit Collection 1
+343
+Unit Collection 2
+344
+Remove Units from Collection
+345
+Returns a collection of all the units of the specified unit collection that are not included in the specified removed units collection.
+346
+Removed Units
+347
+Head of Unit Collection
+348
+Returns a collection containing the first HeadSize elements of the specified unit collection. If the specified HeadSize is greater than the number of elements in the specified unit collection - the entire unit collection is returned.
+349
+Unit Collection
+350
+Head Size
+351
+Shuffled Unit Collection
+352
+Returns a collection containing the units of the specified unit collection in random order.
+353
+Null Object
+354
+Returns a null object, which is a non-existent object. Used to designate a "missing" object value.
+355
+Object Equals
+356
+Returns "true" if Object1 and Object2 (parameters) are the same object.
+357
+Object 1
+358
+Object 2
+359
+Null Object Collection
+360
+Returns an empty object collection.
+361
+Object as Collection
+362
+Returns an object collection containing the specified object parameter.
+363
+Object
+364
+Object Collection Count
+365
+Returns the number of objects in the specified object collection parameter.
+366
+Object Collection
+367
+Object in Collection
+368
+Returns an object of the specified collection parameter corresponding to the specified index parameter (1-based). If the specified index is out of the collection's bounds - an exception is thrown.
+369
+Object Index in Collection
+370
+Returns the index (1-based) of the first occurrence of the specified object in the specified collection. If the specified object does not appear in the specified collection - NullInteger is returned.
+371
+Add Objects to Collection
+372
+Returns a collection containing all the objects of the specified ObjectCollection1 followed by all the objects of the specified ObjectCollection2.
+373
+Object Collection 1
+374
+Object Collection 2
+375
+Remove Objects from Collection
+376
+Returns a collection of all the objects of the specified object collection that are not included in the specified removed objects collection. Note: the order of the objects in the specified object collection is preserved in the result.
+377
+Removed Objects
+378
+Shuffled Object Collection
+379
+Returns a collection containing the objects of the specified object collection in random order.
+380
+Null Task
+381
+Returns a null task, which is a non-existent task. Used to designate a "missing" task value.
+382
+Task Equals
+383
+Returns "true" if Task1 and Task2 (parameters) are the same task.
+384
+Task 1
+385
+Task 2
+386
+Task ID
+387
+Returns the internal ID of the specified task as a string value.
+388
+Task
+389
+Allocation
+390
+Returns an allocation of the specified native type, quantity and duration.
+391
+Native Type
+392
+Quantity
+393
+Null Allocation
+394
+Returns a null allocation, which is a non-existent allocation. Used to designate a "missing" allocation value.
+395
+Allocation Equals
+396
+Returns "true" if Allocation1 and Allocation2 (parameters) are equal.
+397
+Allocation 1
+398
+Allocation 2
+399
+Native Type of Allocation
+400
+Returns the native type of the specified allocation.
+1045
+Seconds
+1046
+Minutes
+1047
+Hours
+1048
+Days
+1049
+Boolean to Yes/No
+1050
+Returns the specified boolean values as a YN_YesNo enumeration value.
+1051
+Polyline from Safe Line
+1052
+Returns a polyline whose points are copied from the line parameter. If a null line is received - a null polyline is returned.
+1053
+TimeSpan to Minutes
+1054
+Returns the number of whole minutes in the specified TimeSpan parameter. If the specified TimeSpan parameter is a null time span - a null integer is returned.
+1055
+String to Integer
+1056
+Returns the numerical value represented by the specified string. Examples: - StringToInteger("00234.900") = 234 - StringToInteger("8706") = 8706 If the specified string does not represent a valid numerical value - a null integer is returned.
+1057
+Kilometer per Hour to Meter per Second
+1058
+Returns the speed in meters per second equal to the specified kilometers per hour value.
+1059
+Kilometer per Hour
+1060
+Meter per Second to Kilometer per Hour
+1061
+Returns the speed in kilometers per hour equal to the specified meters per second value.
+1062
+Meter per Second
+1063
+Polygon from Exact Polyline
+1064
+Returns a "strip" polygon based on the specified polyline parameter, whose width (in meters) is specified by the width parameter. The polyline parameter therefore defines the central "backbone" of the "strip" polygon. If the specified IncludeSemiCircles is 'true' - the returned polygon includes two fairly accurate semi-circles around the first and last points of the specified polyline parameter, so that it actually contains all the points whose distance from the specified polyline is not greater than half the specified width.
+1065
+Include Semi-Circles
+1066
+Polygon from Approximate Polyline
+1067
+Returns a "strip" polygon based on the specified polyline parameter, whose width (in meters) is specified by the width parameter. The polyline parameter therefore defines the central "backbone" of the "strip" polygon. If the specified IncludeSemiCircles is 'true' - the returned polygon includes two approximate semi-circles around the first and last points of the specified polyline parameter, so that it actually contains all the points whose distance from the specified polyline is not greater than half the specified width.
+1068
+Decimal Minute to TimeSpan
+1069
+Returns a TimeSpan value equal to the specified decimal minute - an integer representing a specific minute in a 24-hour day as a value between 0 - 2359. For example: - 1739 represents 17:39 - 125 represents 01:25.
+1070
+Decimal Minute

--- a/hebrew/translated/Core Doctrine DRY_dictionary_heb.txt
+++ b/hebrew/translated/Core Doctrine DRY_dictionary_heb.txt
@@ -1,0 +1,2 @@
+7
+Entire Unit

--- a/hebrew/translated/Core Doctrine_dictionary_heb.txt
+++ b/hebrew/translated/Core Doctrine_dictionary_heb.txt
@@ -1,0 +1,12 @@
+7
+Entire Unit
+48
+Empty Command
+49
+This command does nothing.
+50
+Fail Execution
+51
+Executing this command causes an immediate failure.
+59
+Execute idle command - so that the cell is not empty.

--- a/hebrew/translated/Mamraz Doctrine - AF Targets_dictionary_heb.txt
+++ b/hebrew/translated/Mamraz Doctrine - AF Targets_dictionary_heb.txt
@@ -1,0 +1,220 @@
+1
+Storage
+2
+Inserting sub-units (components) into suitable storage sites located near the specified "storage location". If the unit is more than 2 km away from the specified "storage location" - a unit movement will be performed first to arrive in an orderly manner near the "storage location". Components for which a suitable storage site is not found will remain outside. The command is "infinite", meaning it does not end on its own.
+3
+At the "storage location" - if specified, otherwise at the unit's current location.
+4
+Storage Location
+5
+If not specified - the storage location is the unit's current location.
+6
+Entire Unit
+7
+If the unit is more than 2 km away from the specified "storage location" - move to the specified "storage location".
+Inserting sub-units into storage.
+8
+The unit is more than 2 km away from the specified "storage location"
+9
+Inserting sub-units into storage
+10
+Inserting subordinate units that can be stored into suitable storage sites located near the specified "storage location" (within a range of up to 800m from it).
+11
+The command does not end, so that the sub-units will continue to execute the "storage" command given to them.
+12
+Sub-unit
+13
+Movement to the selected storage site
+Storage.
+14
+A storage site was found for the unit
+15
+Deployment
+16
+Deployment of subordinate units "in the field" or in nearby, suitable, intact and available containing infrastructures (dugouts, etc.). If the unit is deployed - it will be folded first. If the unit is more than 2 km away from the specified "deployment location" - a unit movement will be performed to arrive in an orderly manner at the "deployment location".
+17
+At the "deployment location" - if specified, otherwise at the unit's current location.
+18
+Deployment Location
+19
+The center of the unit's deployment area. If not specified - the deployment location is the unit's current location.
+20
+Deployment Direction
+21
+If not specified - the deployment direction is derived from the general direction (out of the eight directions) to which the unit is facing.
+22
+Avoid entering infrastructures
+23
+Whether to avoid entering containing infrastructures - even if they exist, and in any case to prefer deployment in the field - outside of infrastructures. Default - 'No'.
+24
+Deployment Duration
+25
+This parameter allows forcing a shorter or longer deployment duration than the typical duration if necessary - to achieve a training objective. If no value is specified, the deployment duration of each sub-unit will be according to its type's characteristic.
+26
+If there is at least one deployed sub-unit - fold.
+If the unit is more than 2 km away from the specified "deployment location" - move to the specified "deployment location".
+Company deployment of sub-units.
+27
+There is at least one deployed sub-unit
+28
+The unit is more than 2 km away from the specified "deployment location"
+29
+Company deployment of sub-units
+30
+Deployment of sub-units (components) around the specified "deployment location". Components for which a suitable containing infrastructure was not found within a range of up to 800m from the specified "deployment location" - will be located according to a "field" deployment template (relative distance and azimuth to the "deployment location") - if defined for them, otherwise they will remain in their place.
+31
+The center of the unit's deployment area.
+32
+Whether to avoid entering containing infrastructures - even if they exist, and in any case to prefer deployment in the field - outside of infrastructures.
+33
+This parameter allows forcing a shorter or longer deployment duration than the typical duration if necessary, to achieve a training objective. If no value is specified, the deployment duration of each sub-unit will be according to its type's characteristic.
+34
+If a deployment location is found for the unit
+      Movement to the designated deployment location for the unit
+      Deployment
+      Taking positions facing outwards (outwards from the "deployment location").
+35
+A deployment location was found for the unit
+36
+Folding
+37
+Folding all deployed sub-units.
+38
+Folding Duration
+39
+This parameter allows forcing a shorter or longer folding duration than the typical duration if necessary - to achieve a training objective. If no value is specified, the folding duration of each deployed sub-unit will be according to its type's characteristic.
+40
+Aggregative unit
+41
+Folding.
+42
+The unit is a direct subordinate which is not completely folded (contains at least one simple deployed unit).
+43
+Deployed unit
+44
+The unit is a direct subordinate that is deployed.
+45
+The unit is deployed.
+46
+Follow Unit
+47
+Following a unit
+48
+Unit to follow
+49
+Unit that is supposed to be followed.
+50
+Checks if the unit to follow is of type ammunition group
+51
+Move to coordinate
+52
+Location in containing infrastructures (administrative)
+53
+Changing the location ("jumping") of ammunition groups of the specified type belonging to the unit, to suitable containing infrastructure object locations. The placement of the ammunition groups to objects is done in frameworks with the specified placement echelon. If a military area type is specified and the framework is inside an area of the specified type - the search for containing infrastructure objects is limited to the area of the containing military area, otherwise - the search is limited to the circular area defined by the specified search range from the framework's location.
+54
+Ammunition group type
+55
+The command only operates on ammunition groups of this type. If no value is specified - the command operates on all types of ground ammunition groups.
+56
+Search range (meters)
+57
+The search range for containing infrastructure objects, from the location of each framework that is not inside a "military area type". If no value is specified - the search range is 2,500 meters.
+58
+A value greater than zero must be entered
+59
+Placement echelon
+60
+The echelon of the frameworks in which the placement will be performed.
+61
+An echelon that is not lower than "company" and not higher than the echelon of the unit receiving the command must be specified.
+62
+Military area type
+63
+For each subordinate framework with the specified "placement echelon" located within a military area of this type, the search for containing infrastructure objects is limited to the area of the containing military area.
+64
+Entire unit
+65
+If the unit's echelon is the specified placement echelon
+      Then      Perform placement in containing infrastructures - ammunition groups
+      Else  Perform placement in containing infrastructures - framework-based.
+66
+Placement in containing infrastructures - framework-based (administrative)
+67
+Changing the location ("jumping") of ammunition groups of the specified type belonging to the unit, to suitable containing infrastructure object locations.
+68
+Direct subordinate
+69
+Recursive activation on subordinate frameworks in an echelon not lower than the specified placement echelon.
+70
+The unit is a direct subordinate
+71
+Subordinate frameworks in an echelon not lower than the specified placement echelon
+72
+Placement in containing infrastructures - ammunition groups (administrative)
+73
+If there is at least one ammunition group that needs to be located - move to a suitable containing infrastructure.
+74
+At least one ammunition group must be located
+75
+Military area search range
+76
+Default for search range of containing infrastructures
+77
+Collection of subordinate ammunition groups participating in the process
+78
+Move to suitable containing infrastructure
+79
+Moving ammunition groups to a suitable containing infrastructure, according to the placement results.
+80
+Ammunition groups to be located
+81
+Suitable containing infrastructures
+82
+Collection of suitable containing infrastructures (by index) for the ammunition groups designated for placement.
+83
+For framework: Move to suitable containing infrastructure - framework-based.
+For ammunition group: If a suitable containing infrastructure is found - move the unit to the location of this infrastructure.
+84
+Move to suitable containing infrastructure - framework-based
+85
+Only a direct subordinate unit should be placed. An ammunition group should only be placed if it appears in the specified collection of ammunition groups for placement.
+86
+Activate/deactivate countermeasures
+87
+Activation/deactivation of the various countermeasures existing in the unit: passive measures - camouflage and smoke screening, and active measures - radar jammer and GPS blocker.
+88
+Camouflage
+89
+The new state of camouflage in the executing unit. An empty value means that the state of camouflage in the unit will remain unchanged.
+90
+Smoke screening
+91
+The new state of smoke screening in the executing unit. An empty value means that the state of smoke screening in the unit will remain unchanged.
+92
+GPS blocker
+93
+The new state of the GPS blocker in the executing unit. An empty value means that the state of the GPS blocker in the unit will remain unchanged.
+94
+Radar jammer
+95
+The new state of the radar jammer in the executing unit. An empty value means that the state of the radar jammer in the unit will remain unchanged.
+96
+Activate/deactivate countermeasures.
+97
+Simple unit
+98
+Set radar operating mode
+99
+Setting an operating mode for all existing radars in subordinate units.
+100
+Operating mode
+101
+The new operating mode of all existing radars in subordinate units.
+102
+Set radar operating mode.
+103
+Unit with radar
+104
+The unit is a direct subordinate and has a radar
+105
+The unit has a radar

--- a/hebrew/translated/Mamraz Doctrine - Advance_dictionary_heb.txt
+++ b/hebrew/translated/Mamraz Doctrine - Advance_dictionary_heb.txt
@@ -1,0 +1,221 @@
+1
+Framework Advancement
+2
+Advancement along a route where the main force is secured from four directions by dedicated guards. The purpose of the advancement is to bring the main force to the end of the route.
+3
+End of the main route
+4
+Sector Boundaries
+5
+Delineation of the area within which the advancement maneuver is performed.
+6
+Main Route
+7
+The route along which the main force will move.
+8
+Right Guard Route
+9
+The route along which the right guard will move.
+10
+Left Guard Route
+11
+The route along which the left guard will move.
+12
+Line of Deployment
+13
+The line on which the leading vehicles will align in the initial deployment phase (entering movement formation). The starting line must cross the forces' movement routes.
+14
+A line of deployment or a point of deployment must be defined, but not both.
+15
+Deployment Point
+16
+The point on the main route where the leading vehicles will align in the initial deployment phase (entering movement formation).
+17
+A deployment point must be defined in a built-up area.
+18
+Is it a built-up area
+19
+Is the advancement intended to be carried out through a built-up area terrain (relevant for battalion-level advancement only)
+20
+Brigade-level advancement cannot be performed in a built-up area
+21
+The attrition level of the front guard (or the leader in advancement in a built-up area) is too high. The advancement has stopped.
+22
+Entire Unit
+23
+Phase A: Boarding vehicles and deploying in movement formation behind the starting line.
+Phase B: Coordinated movement along the advancement route.
+24
+The strongest unit
+25
+The second strongest unit
+26
+Left Guard
+27
+Right Guard
+28
+Main Force
+29
+Finish Line
+30
+End Point
+31
+Framework Advancement - Implementation
+32
+The line on which the leading vehicles will align as part of the initial deployment phase (entering movement formation). The starting line must cross the forces' movement routes.
+33
+Front Guard
+34
+Leader
+35
+Passing through a built-up area
+36
+Movement on axes
+37
+Hide from enemy units
+38
+This is the last iteration (the number of iterations is stored in the memory of the front guard unit)
+39
+In the first iteration: Deployment along the route - according to the starting line.
+In each subsequent iteration: Movement along the next segment of the route.
+40
+In the first iteration
+41
+In the second iteration
+42
+In every iteration that is not the first
+43
+In the last iteration
+44
+Logistic units (only) from the battalion should be allowed to be assigned to the side columns.
+45
+Headquarters
+46
+Brigade-level unit,
+The assignment to this mission remains fixed for the entire duration of the execution.
+47
+Priority for assignment - according to strength.
+48
+Leader of the central column
+49
+In the first iteration: Remember the number of iterations and deploy along the route - according to the starting line.
+In each subsequent iteration: Movement along the next segment of the route.
+50
+The battalion's logistic units are supposed to be assigned to the side columns.
+51
+The unit is assigned to its mission for the first time
+52
+In every middle iteration
+53
+The attrition level is too high.
+54
+A company from the front guard should not be assigned,
+A side guard company that has already abandoned its mission should not be assigned again.
+55
+Right Column
+56
+Brigade-level units only at company/battalion level.
+The assignment to this mission remains fixed for the entire duration of the execution.
+57
+Logistic company/platoon from the front guard (directly subordinate).
+58
+Left Column
+59
+Rear Guard
+60
+A company from the front guard should not be assigned.
+The assignment to this mission remains fixed for the entire duration of the execution.
+61
+Former side guard
+62
+Movement to the nearest point on the central route
+Transfer of command to the leader of the central column.
+63
+Attrition level too high for a side guard. Disengaging and joining the central column.
+64
+Side guard company that has abandoned its mission.
+65
+Tail of the central column
+66
+Central Column
+67
+Brigade-level units only at company/battalion level.
+68
+The maximum percentage of damaged vehicles in the side guards (right/left) that still allows them to continue their mission.
+69
+The maximum distance from the deployment point that allows for arrival on foot (for built-up areas only)
+70
+The arrival point distance of the guards from the deployment point (for built-up areas only)
+71
+Brigade Advancement
+72
+Deployed along the route
+73
+I have finished deploying along my route, waiting for the rest of the forces.
+74
+Starting to advance along the route
+75
+I have reached my destination point on the route. Waiting for the rest of the forces to finish their advancement.
+76
+Minus two - which are the front guard and the leader of the central column
+77
+The right guard unit is assigned to its mission for the first time
+78
+The left guard unit is assigned to its mission for the first time
+79
+This tail unit is assigned to its mission for the first time
+80
+Distance between the last vehicle of the front guard and the first vehicle of the main force
+81
+Arrival on vehicles of the front guard is required
+82
+Arrival on vehicles of the right guard is required
+83
+Arrival on vehicles of the left guard is required
+84
+Arrival point of the guards for a built-up area
+85
+The length of the route segment on which coordinated movement is required - from the deployment point of the front guard onwards.
+86
+In any case, no less than two iterations:
+First for deployment on the starting line.
+Last for reaching the end of the route.
+87
+End of the current movement segment on the central route
+88
+If this is the last iteration - the interval point is forced to the end of the central route
+98
+Attrition threshold for leading units
+99
+The maximum percentage of damaged vehicles or unfit soldiers in the front guard and the leader that still allows the advancement to continue.
+100
+Attrition threshold for side guard
+101
+The maximum percentage of damaged vehicles in a side guard (right/left) that still allows the advancement to continue.
+102
+Leading the front guard
+103
+Distance between the last vehicle of the front guard and the first vehicle of the main force during a framework advancement. The distance depends on the echelon of the moving unit and the terrain through which the route passes:
+- For a brigade: 2000 meters
+- For a battalion in open terrain: 1000 meters
+- For a battalion in closed terrain: 400 meters
+104
+Echelon
+105
+The brigade must contain at least two armored/mechanized infantry battalions
+106
+Must be within the sector boundaries
+107
+Must cross the three movement routes (main route and side guard routes)
+108
+Battalion advancement in open terrain
+109
+Advancement along a route in open terrain where the main force is secured from the front and sides by dedicated guards. The purpose of the advancement is to bring the main force to the end of the route.
+110
+The battalion must contain at least two companies of infantry, armor, or mechanized infantry
+111
+Battalion advancement in a built-up area
+112
+Advancement along a route that passes through a closed area where the main force is secured from the front and sides by dedicated guards. The purpose of the advancement is to bring the main force to the end of the route.
+113
+The point must be on the main route (up to 50 m').

--- a/hebrew/translated/Mamraz Doctrine - Airborne_dictionary_heb.txt
+++ b/hebrew/translated/Mamraz Doctrine - Airborne_dictionary_heb.txt
@@ -1,0 +1,118 @@
+1
+Collection flight on a common route
+2
+Cyclic flight of a formation of collection aircraft in a coordinated arrangement, along a common route. During their flight, the aircraft maintain constant and equal distances from each other.
+3
+Flight Path
+4
+The common circular route along which the collection flight will be carried out.
+5
+The formation must include only 2-3 collection aircraft.
+6
+Aircraft 1
+7
+Flight along the specified flight path.
+8
+Aircraft 2
+9
+Flight along the specified flight path, while maintaining an appropriate distance from aircraft 1.
+10
+Aircraft 3
+11
+Flight along the specified flight path, while maintaining an appropriate distance from aircraft 2.
+12
+Collection flight on a common circular route
+13
+Cyclic flight of a formation of collection aircraft in a coordinated arrangement, along a common circular route, around the specified focus. During their flight, the aircraft maintain constant and equal distances from each other.
+14
+Focus
+15
+The center of the circle along which the collection flight will be carried out.
+16
+Entire Unit
+17
+Collection flight on separate routes
+18
+Cyclic flight of a formation of collection aircraft in a coordinated arrangement, along separate routes. The aircraft maintain synchronization during the flight, so that at any given moment they are all in the same relative part of their route.
+19
+Flight Path 1
+20
+The route designated for the first aircraft in the formation.
+21
+Flight Path 2
+22
+The route designated for the second aircraft in the formation.
+23
+Flight Path 3
+24
+The route designated for the third aircraft in the formation - if it exists.
+25
+This value should not be entered for a formation that includes only two aircraft. This value must be entered for a formation that includes three aircraft.
+26
+Flight along flight path 1, at the speed required to maintain synchronization with the other aircraft in the formation.
+27
+Flight along flight path 2, at the speed required to maintain synchronization with the other aircraft in the formation.
+28
+Flight along flight path 3, at the speed required to maintain synchronization with the other aircraft in the formation.
+29
+The unit is a valid collection formation
+30
+A 'true' value is returned if the specified unit (Unit) includes only 2-3 atomic units, all of which are of the "collection aircraft" type.
+32
+EW flight on a common route
+33
+Cyclic flight of a formation of EW aircraft in a coordinated arrangement, along a common route. During their flight, the aircraft maintain constant and equal distances from each other.
+34
+Transmission Segment
+35
+The part of the total circular flight path in which EW transmission is to be performed.
+36
+The formation must include only EW aircraft (at least one), all of the same type.
+37
+Non-transmission segment
+38
+The part of the total circular flight path in which EW transmission is not to be performed. If not specified - it means that transmission is to be performed along the entire circular flight path.
+39
+Flight altitude (feet)
+40
+The absolute altitude (above sea level) at which the flight will be carried out, in feet. If no flight altitude is specified, the flight will be carried out at the typical flight altitude for the unit type.
+41
+Must be greater than zero.
+42
+Flight Duration
+43
+The execution will end after the specified duration. If not specified - the flight continues without interruption (until another command is received).
+44
+EW aircraft
+45
+Turning off EW equipment. Flight along a circular path while turning EW equipment on/off according to the current location on the path. Turning off EW equipment. Setting the location ("jumping") to the initial location before the flight.
+47
+Turning EW equipment on/off during the flight - according to the current location on the flight path.
+48
+The current location is on the total circular flight path
+49
+This check is intended to prevent unwanted activation/deactivation of EW equipment before and after the flight.
+50
+The current location is on the specified "non-transmission segment"
+51
+Turn off EW equipment
+52
+Turn on EW equipment
+53
+Time-limited flight along a circular path
+54
+Cyclic time-limited flight along a circular flight path, at the specified altitude and at the typical speed for the platform type. If the unit is not at the beginning of the specified flight path - it is "jumped" there at the beginning of the execution.
+55
+The circular route along which the flight will be carried out cyclically.
+56
+Start Point
+57
+The point on the specified circular flight path from which the flight will begin.
+58
+End Time
+59
+The flight will end at the specified time.
+60
+The flight's end time has arrived
+61
+Flight along a circular path.

--- a/hebrew/translated/Mamraz Doctrine - Airforce Common_dictionary_heb.txt
+++ b/hebrew/translated/Mamraz Doctrine - Airforce Common_dictionary_heb.txt
@@ -1,0 +1,391 @@
+1
+Set first takeoff point
+2
+Set the "first takeoff point" value in the permanent memory of the executing formation.
+3
+First takeoff point
+4
+Entire unit
+5
+Set allow takeoff before preparation completion
+6
+Set the "allow takeoff before preparation completion" value in the permanent memory of the executing formation.
+7
+Allow takeoff before preparation completion
+8
+Set leader number
+9
+Set the "leader number" value in the permanent memory of the executing formation.
+10
+Leader number
+11
+Set original operation ID
+12
+Set the "original operation ID" value in the permanent memory of the executing formation.
+13
+Original operation ID
+14
+Set last takeoff time
+15
+Set the "last takeoff time" value in the permanent memory of the executing formation.
+16
+Last takeoff time
+17
+Set original executed mission order ID
+18
+Set the "original executed mission order ID" value in the permanent memory of the executing formation.
+19
+Original executed mission order ID
+20
+Send targeting point verification status reports to the cluster
+21
+Send a targeting point verification/cancellation report to the C2 system, for the cluster's targeting point.
+22
+Cluster
+23
+Verification status
+24
+Is airborne
+25
+Airborne
+26
+Not airborne
+27
+Register anchor event
+28
+Send a message to the formation about meeting the anchor time at the end of a scheduled flight along a route.
+29
+Anchor event
+30
+Arrival time
+31
+The arrival time at the end of the flight path. If not specified - the actual arrival time is the current time.
+32
+Arrival at anchor time for
+33
+at
+34
+late
+35
+early
+36
+of
+37
+Register anchor event of a formation
+38
+Send a message by the specified formation about meeting the anchor time at the end of a scheduled flight along a route.
+39
+Air unit
+40
+Request to register anchor event
+41
+Request to register an anchor event by the receiving formation.
+42
+Response to request to register anchor event
+43
+Activate anchor event registration in response to a request.
+44
+Set execution policy
+45
+Set a policy that affects all commands executed by the formation, in terms of flight, attack, and transmission status.
+46
+Set [Attack profile to "Attack profile"] [Delivery policy to "Delivery policy"]
+[Perform ground verification (yes|no)]
+[Flight approval in threat zone to "Flight approval in threat zone"]
+[Transmit Mode 1 and Mode 2 (yes|no)]
+[Transmit Mode 3 and Mode C (yes|no)]
+[Transmit C2 (yes|no)]
+[Fly without fuel warnings (yes|no)]
+47
+Only components for which a value was specified appear.
+48
+Set
+49
+Attack profile to
+50
+Delivery policy to
+51
+Perform ground verification
+52
+Flight approval in threat zone
+53
+Transmit Mode 1 and Mode 2
+54
+Transmit C2
+55
+Fly without fuel warnings
+56
+Attack profile
+57
+If not specified - the attack profile remains unchanged. If an attack profile has not yet been defined - the attack profile in the execution policy is set to "hunt".
+58
+Delivery policy
+59
+If not specified - the delivery policy remains unchanged. If a policy has not yet been defined - the policy is set to "direct delivery".
+60
+Whether to perform a ground verification report for the targeting points intended for attack before the first takeoff. If not specified - the value in the execution policy remains unchanged. The default is to perform ground verification.
+61
+How to treat a threat zone when planning flight paths for the formation.
+62
+Transmit Mode 1 and Mode 2
+63
+Whether to transmit Mode 1 and Mode 2 data for the benefit of the control systems.
+64
+Transmit Mode 3 and Mode C
+65
+Whether to transmit Mode 3 (IFF) and Mode C (flight altitude) data for the benefit of the control systems.
+66
+Whether to transmit C2 data.
+67
+Whether to fly without warning about low fuel situations (sonol/bingo).
+68
+At least one of the parameters must be filled.
+69
+1. Execute the "Set mission instructions (atomic)" command with the relevant parameters from those specified.
+
+2. Execute the "Set transmission status" command with the relevant parameters from those specified.
+
+3. Send a message to the formation: "[Parameter name] set to [Parameter value]." for each specified (non-empty) parameter.
+70
+Set mission instructions
+Set transmission status
+Send messages
+71
+Set transmission status
+72
+Set the values of the codes used to identify the formation's aircraft in the air control systems (including civil air control), the transmission status (off/on) of each of them, and the transmission status of C2 data. An empty value for a parameter means that the value of the corresponding attribute in the formation remains unchanged.
+73
+Set [Mode 1 code to "Mode 1 code"]
+[Transmit Mode 1 (yes|no)]
+[Mode 2 code to "Mode 2 code"]
+[Transmit Mode 2 (yes|no)]
+[Mode 3 code to "Mode 3 code"]
+[Transmit Mode 3 (yes|no)]
+[Transmit Mode C (yes|no)]
+[Transmit C2 (yes|no)]
+74
+Mode 1 code to
+75
+Transmit Mode 1
+76
+Mode 2 code to
+77
+Transmit Mode 2
+78
+Mode 3 code to
+79
+Transmit Mode 3
+80
+Mode 1 code
+81
+Octal number (digits 0-7), with at most two digits.
+82
+An octal number (digits 0-7), with at most two digits, must be specified.
+83
+Transmit Mode 1
+84
+Whether to transmit Mode 1 data for the benefit of the control systems.
+85
+Mode 2 code
+86
+Octal number (digits 0-7), with at most four digits.
+87
+An octal number (digits 0-7), with at most four digits, must be specified.
+88
+Transmit Mode 2
+89
+Whether to transmit Mode 2 data for the benefit of the control systems.
+90
+Mode 3 code
+91
+Transmit Mode 3
+92
+Whether to transmit Mode 3 (IFF) data for the benefit of the control systems.
+93
+Transmit Mode C
+94
+Whether to transmit Mode C (flight altitude) data for the benefit of the control systems.
+95
+Send manual ROGER report
+96
+Send a report to the C2 system to confirm receipt and understanding of updates received from it regarding the executed mission order.
+97
+Cannot send manual ROGER report. The formation is not executing a mission order.
+98
+Cannot send manual ROGER report. The formation has not yet taken off.
+99
+Applicable executed mission order ID
+100
+The formation is not executing a mission order
+101
+The formation has not yet taken off
+102
+The report cannot be sent
+103
+The report can be sent
+104
+The formation's first takeoff point.
+105
+Formation
+106
+Whether the formation takes off in any case upon reaching the "planned first takeoff time", even if the ground preparation process has not yet been completed.
+107
+Landed formation
+108
+Whether the specified formation is landed (on the ground). A 'yes' value is returned if the current flight speed is zero and the current altitude is equal to the ground level altitude at the current location up to an epsilon (5 meters).
+109
+Formation has performed first takeoff
+110
+Whether the specified formation has already performed its first takeoff. A 'yes' value is returned if the "last takeoff time" stored in the formation's memory is not empty.
+111
+The serial number of the formation's leader. In an original formation, the leader's number is always 1. In the case of a formation split, the leader's number in the new formation (containing the departing aircraft) is necessarily greater than 1.
+112
+An empty value for "leader number" is typical for an original formation and is therefore equivalent to the value 1.
+113
+Formation is on approach for landing
+114
+Whether the specified formation is in the process of approaching for landing. A 'yes' value is returned if the formation is airborne and is flying along a path with "landing on arrival" and has already entered the base's control zone (in practice: the end point of the current flight path, which is not necessarily at the base's location).
+115
+Formation is airborne
+116
+Whether the specified formation is airborne (flying). A 'yes' value is returned if it is not landed.
+117
+Value of "original operation ID" from the permanent memory of the specified formation.
+118
+Applicable operation ID
+119
+The applicable operation ID for the specified formation. If the formation has a defined executed mission order - this is the operation containing the mission order, otherwise it is the "original operation ID" value stored in the formation's memory. Note: the "original operation ID" value is stored in the memory of a formation created as part of a formation split, so as not to lose its link to the operation of the mission order executed by the original formation.
+120
+Formation has an anchor time defined
+121
+Whether an anchor time is defined in the mission instructions of the specified formation.
+122
+Formation is allowed to fly at full power
+123
+Whether the formation is allowed to fly at the maximum possible speed, in order to meet an arrival time target.
+124
+Full name
+125
+The full name of a formation is composed of the concatenation of the suffix to the name with the formation's name. The suffix to the name contains the numbers of the aircraft in the formation that has been split.
+126
+Applicable operation name
+127
+The name of the operation with the applicable operation ID (tactical function) for the specified formation (empty string if none).
+128
+Value of "original executed mission order ID" from the permanent memory of the specified formation.
+129
+The applicable executed mission order ID for the specified formation is the executed mission order ID by it - if it is not empty, otherwise it is the "original executed mission order ID" value stored in the formation's memory. Note: the "original executed mission order ID" value is stored in the memory of a formation created as part of a formation split, so as not to lose its link to the mission order executed by the original formation.
+130
+Platform category by type
+131
+The air platform category to which the specified air platform type (class name) is assigned.
+132
+Air platform type (class name)
+133
+Air platform category
+134
+The air platform category to which the specified air unit belongs.
+135
+Enumeration change summary
+136
+Summary content for changing an enumeration type attribute value. If the value is empty - an empty string, otherwise - the concatenated string of the prefix and the value. A yes/no value is enclosed in parentheses.
+137
+Prefix
+138
+Value
+140
+Integer change summary
+141
+Summary content for changing an integer type attribute value. If the value is empty - an empty string, otherwise - the concatenated string of the prefix and the value.
+142
+Real number change summary
+143
+Summary content for changing a real number type attribute value. If the value is empty - an empty string, otherwise - the concatenated string of the prefix and the value.
+144
+Policy change message
+145
+Content of a message to the formation about a policy value change.
+146
+Policy name
+147
+Policy value
+148
+Set to
+149
+Takeoff/landing site name
+150
+The name of the specified base/landing strip/coordinate. If a coordinate is specified - this is the name of the coordinate or its coordinate value - if it has no name, otherwise if a landing strip is specified - this is the name of the landing strip or its coordinate value - if it has no name, otherwise if a base is specified - this is the name of the base, otherwise - an empty string.
+151
+Base
+152
+Landing strip
+153
+Coordinate
+154
+Base
+155
+Landing strip
+156
+Coordinate
+187
+Representative anchor event
+188
+The representative event for the specified anchor event is determined as follows: for takeoff - takeoff, for stabilization/circle - stabilization, for direction exit - direction exit, for delivery/launch - delivery, for impact - impact.
+189
+Anchor event
+190
+Matching anchor events
+191
+A 'yes' value is returned if the representative anchor event (tactical function) of "anchor event 1" is equal to the representative anchor event of "anchor event 2".
+192
+Anchor event 1
+193
+Anchor event 2
+194
+Entry point to base control zone
+195
+The last point on the specified landing path where it enters the base control zone around the landing point (end of the path). If the entire landing path is within this zone - a "null point" value is returned.
+196
+Landing path
+197
+Base control radius (CTR)
+198
+The radius (in miles) of the circular area around a base supervised by the base's control tower. Note: in reality this area is not circular. Representing the area as a circle is only an approximation.
+202
+Actual specified sector
+203
+The actual specified sector is: - the specified sector - if it is not empty. - otherwise - the sector used by the specified entry corridor - if it is not empty. - otherwise - the sector used by the specified holding area - if it is not empty. - otherwise - an empty value.
+204
+Specified sector
+205
+Specified entry corridor
+206
+Specified holding area
+207
+Road does not match sector
+208
+A road does not match a sector if both are not empty and also (the road is not linked to this sector or its purpose of use is different from the specified purpose of use).
+209
+Road
+210
+Sector
+211
+Purpose of use
+216
+Range of influence of a central control post (MOSHEL)
+217
+The range of influence of a central control post (MOSHEL) of the Air Force regarding the closure of a nearby base/landing strip.
+218
+Nearby Air Force central control post (MOSHEL)
+219
+An ammunition group of type Air Force central control post (MOSHEL) located within the range of influence of a central control post (tactical function) from the specified coordinate. If there is no such unit - an empty value is returned.
+220
+End time of takeoff/landing site closure
+221
+The end time of the takeoff/landing site closure stored in the memory of the Air Force central control post (MOSHEL) near the specified coordinate. An empty return value means that no closure restriction applies to the specified coordinate and it is possible to take off and land from it at any time.
+222
+Flight path length (in nautical miles)
+223
+The length of the specified flight path in nautical miles.
+224
+Flight path

--- a/hebrew/translated/Mamraz Doctrine - Airforce DRY_dictionary_heb.txt
+++ b/hebrew/translated/Mamraz Doctrine - Airforce DRY_dictionary_heb.txt
@@ -1,0 +1,154 @@
+4
+Entire Unit
+14
+Flight approval in threat zone
+15
+How to treat a threat zone when planning flight paths for the formation.
+17
+Attack profile
+18
+The profile according to which the targets should be attacked.
+19
+Set anchor time of a formation (land)
+20
+Last takeoff time
+21
+Set anchor event of a formation (land)
+22
+Anchor event of a formation
+23
+Set last takeoff time (land)
+24
+Set first takeoff point (land)
+25
+Dry substitute.
+26
+First takeoff point
+32
+Flight along a path (atomic) (land)
+33
+Path
+34
+The path along which to fly.
+35
+Initial speed
+36
+The initial speed (relative to the ground) at which the flight begins - in knots. If not specified - the flight begins at the current speed.
+37
+Initial altitude
+38
+The absolute altitude (above sea level) at which the flight begins - in thousands of feet. If not specified - the flight begins at the current altitude.
+39
+Land at the end
+40
+Whether to land (i.e. descend to ground level) at the end point of the specified path.
+41
+In case of not landing at the end, the flight end altitude is arbitrarily set to the desired flight altitude.
+42
+Takeoff
+43
+Takeoff (anchor)
+44
+Landing
+45
+Set flight characteristics (atomic) (land)
+46
+Altitude
+47
+The desired absolute flight altitude (above sea level) in thousands of feet. If no value is specified - the desired flight altitude remains unchanged.
+48
+Speed
+49
+The desired flight speed relative to the ground - in knots. If not specified - the desired flight speed remains unchanged.
+50
+Flight pattern
+51
+The flight pattern in which to fly. If not specified - the current flight pattern is maintained.
+52
+Set mission instructions (atomic) (land)
+53
+Delivery policy
+54
+The delivery policy for ordnance.
+55
+Perform ground verification
+56
+Whether to perform a ground verification report for the targeting points intended for attack before the first takeoff.
+57
+Fly without fuel warnings
+58
+Whether to fly without warning about low fuel situations (sonol/bingo).
+59
+Set timing instructions (atomic) (land)
+60
+Existing alert state
+61
+Alert is a state in which the executing formation is required to wait on the ground for a scramble command, which may precede the planned takeoff time. The existing alert level determines the response time in which the formation is required to meet - between receiving the scramble command and the actual takeoff.
+62
+Alert start time
+63
+The existing alert is valid only from this time.
+64
+Scramble time
+65
+The time at which the scramble command was received for the formation on alert.
+66
+Planned first takeoff time
+67
+The planned time for the formation's first takeoff as part of the mission.
+68
+Anchor time
+69
+The time at which the mission's anchor event is required to occur.
+70
+Anchor event
+71
+The type of the mission's main event - according to which the entire mission is scheduled.
+72
+Anchor event location
+73
+The expected location of the formation when the anchor event occurs. During the execution of the flight plan, a continuous assessment of the ability to reach this location at the anchor time is performed, and an alert is issued if a delay is expected.
+74
+The last takeoff time performed by the formation.
+75
+Required alert state
+76
+The alert state to which the formation is required to transition in case of an alert change. The completion of the transition is expressed by setting the value of the existing alert state to the required alert state.
+77
+Wait (land)
+78
+Wait duration
+79
+If no wait duration is specified - the command will end immediately.
+80
+Wait description
+81
+If a value is specified - a message is sent to the unit in the format "[Wait description] ([Wait duration])".
+82
+Remember the "End time". Wait until the "End time" arrives.
+83
+Save anchor event (land)
+84
+Anchor event
+85
+Arrival time
+86
+The arrival time at the end of the flight path. If not specified - the actual arrival time is the current time.
+87
+Prepare for dry run
+88
+Initialize the memory notes that embody the dynamic state of the unit for a dry run, based on the values of its dynamic attributes.
+96
+Flight approval in threat zone of a formation (land)
+97
+Formation
+98
+Attack profile of a formation (land)
+99
+Anchor time of a formation (land)
+100
+Anchor event of a formation (land)
+101
+Last takeoff time of a formation (land)
+102
+First takeoff point of a formation (land)

--- a/hebrew/translated/Mamraz Doctrine - Airforce Flight_dictionary_heb.txt
+++ b/hebrew/translated/Mamraz Doctrine - Airforce Flight_dictionary_heb.txt
@@ -1,0 +1,1976 @@
+1
+Single orbit to gain time
+2
+Perform a single complete orbit to gain time, so that the flight vector at the end (location and direction) is equal to the initial flight vector.
+3
+Required time gain
+4
+The amount of time that needs to be "wasted" in the orbit.
+5
+1. Gaining time by a complete orbit is always performed at the current flight speed.
+
+2. Performing a complete orbit allows for a continuous and finite range of time gain, as follows:
+
+a. The minimum time gain is achieved by a circular orbit at the current speed.
+
+b. The maximum time gain is achieved by a hippodrome orbit ("popsicle stick") at the minimum practical speed (tactical function), with a straight leg of "maximum straight leg length".
+
+c. The continuous range between (a) and (b) is achieved by extending the straight leg of the hippodrome orbit up to the "maximum straight leg length".
+
+3. The actual time gain is determined as follows: if the required time gain is greater than the maximum time gain - it is the maximum time gain, otherwise it is the required time gain.
+6
+Entire unit
+7
+Maximum straight leg length (nautical miles)
+8
+Flight speed
+9
+Orbit circle length (nautical miles)
+10
+Maximum length of the orbit path (nautical miles)
+11
+Maximum time gain
+12
+Actual time gain
+13
+No straight leg needed
+14
+Length of the straight leg
+15
+The length of the two straight legs is the total flight distance minus the length of the orbit circle. Divide by two to get the length of one straight leg.
+16
+The orbit path
+17
+Orbit to gain time
+18
+Perform orbits to gain time, so that the flight vector at the end (location and direction) is equal to the initial flight vector.
+19
+1. In the first iteration: Remember the "target time for ending time gain" as the current time plus "required time gain".
+
+In each iteration:
+2. "Remaining required time gain" equals the time difference between "target time for ending time gain" and the current time.
+
+3. If "minimum time gain in orbit" (tactical func.) is not greater than "remaining required time gain" (need to gain time): perform a single orbit to gain time with "remaining required time gain".
+20
+Remaining required time gain is less than the minimum time gain in an orbit.
+21
+First iteration
+22
+Target time for ending time gain
+23
+Remaining required time gain
+24
+Need to gain time
+25
+Handling expected delay
+26
+Set the desired flight speed to the maximum authorized flight speed and send a late arrival alert and a request for full power flight approval - as needed.
+27
+Required arrival time
+28
+Remaining flight path length (nautical miles)
+29
+Job ID
+30
+The ID of the job (of a scheduled flight along a path) for which the expected delay is being handled.
+31
+1. Set the desired speed to the maximum authorized speed.
+
+2. The "binding arrival time" is the "required arrival time" if a late arrival alert has not yet been sent, otherwise - the "promised arrival time" by the last alert sent.
+
+3. If the "expected arrival time" is later than the "binding arrival time" plus a tolerable arrival time gap - send a late arrival alert to the formation and remember the "expected arrival time" specified in the alert as the "promised arrival time".
+
+4. If the formation is not authorized for full power flight (atomic function) and a request for full power flight has not yet been sent and the expected arrival time in full power flight is earlier than the "expected arrival time" without full power - send a request for full power flight.
+32
+A late arrival alert should be sent
+33
+A request for full power flight approval should be sent
+34
+Tolerable arrival time gap
+35
+Maximum authorized speed (knots)
+36
+Expected flight duration (at maximum authorized speed)
+37
+Expected arrival time (at maximum authorized speed).
+38
+Expected delay
+39
+Promised arrival time
+40
+Binding arrival time
+41
+Late arrival alert text
+42
+Delay alert! Expected arrival time at current speed: "Expected arrival time" (delay of "Expected delay")
+43
+Delay alert! Expected arrival time at current speed:
+44
+(delay of
+45
+Full power flight speed (knots)
+46
+Expected flight duration in full power flight
+47
+Expected arrival time in full power flight
+48
+Actual arrival time in full power flight
+49
+Full power flight will prevent delay
+50
+Expected delay in full power flight
+51
+Required flight duration for on-time arrival
+52
+Required speed for on-time arrival (knots)
+53
+Actual speed given full power flight approval
+54
+Expected flight duration given full power flight approval
+55
+Fuel consumption at actual speed given full power flight approval
+56
+Fuel consumption at maximum authorized speed
+57
+Fuel loss in full power
+58
+Loss of work time in full power
+59
+Request for full power flight approval text
+60
+If full power flight approval is given, it will be possible to arrive at "Actual arrival time in full power flight" [(with a delay of "Expected delay in full power flight")] | [(on time)] [at the cost of "Loss of work time in full power" loss of work time]
+61
+If full power flight approval is given, it will be possible to arrive at
+62
+(on time)
+63
+at the cost of
+64
+loss of work time
+65
+Set landing state
+66
+Set the flight pattern to "approach for landing".
+67
+Set the flight pattern to "approach for landing".
+Set the mission execution state to "orbit for landing".
+68
+Check for landing at a closed base/landing strip
+69
+Check if the formation's expected landing time is before the end time of the landing site closure (closure by "close nearby base/landing strip" command). If so - send a message to the formation and save an indication that the message was sent in the formation's memory to prevent sending it again.
+70
+Required landing time
+71
+The ID of the job for which to remember that the landing site closure message was sent.
+72
+The expected landing time is:
+- The required landing time - if specified, otherwise
+- The current time plus the flight time on the remainder of the scheduled path (tactical function) at the formation's current desired speed.
+73
+Landing destination (
+74
+) closed until
+75
+but the formation is expected to land before then.
+76
+Current time
+77
+Remainder of scheduled path
+78
+Landing point
+79
+End time of landing site closure
+80
+Current desired flight speed (knots)
+81
+Remaining flight time
+82
+Expected landing time according to desired speed
+83
+Expected landing time
+84
+Landing expected during landing point closure
+85
+A landing site closure message should be sent
+86
+Landing site name
+87
+Perform periodic checks during flight
+88
+Perform periodic checks during "scheduled flight along a path" for the purpose of:
+- Updating the remainder of the scheduled path ("tail trimming")
+- Setting the flight pattern
+- Meeting the required arrival time
+- Sending alerts about fuel status
+- Sending an alert about landing at a closed base/landing strip
+- Responding to the movement of a target being tracked by a UAV.
+89
+The ID of the job (of a scheduled flight along a path) for which the checks are being performed.
+90
+Arrival time
+91
+Land on arrival
+92
+1. Definitions:
+- "Last check time of <check type>" is stored in a memory note for the specified "Job ID". In the first execution of the command, this value is of course empty.
+- "Next check time of <check type>" is equal to "Last check time of <check type>" plus "check frequency of <check type>".
+
+2. Perform an update of the remainder of the scheduled path for tail trimming.
+
+3. For each <check type> perform:
+If this is the first execution or if "Next check time of <check type>" has passed
+    - Perform the <check type>.
+    - Set the value of "Last check time of <check type>" for the specified "Job ID" to the current time value.
+
+Notes:
+- Arrival time check is performed only if an arrival time is specified.
+- Landing at a closed base/landing strip check is performed only if land on arrival is specified.
+- UAV tracking target movement check is performed only during tracking of a target by a UAV.
+93
+Next check time for flight pattern has passed
+94
+An arrival time check should be performed
+95
+Flight pattern check frequency
+96
+Arrival time compliance check frequency
+97
+Fuel constraints check frequency
+98
+Landing at closed base/landing strip check frequency
+99
+UAV tracking target check frequency
+100
+Current location
+101
+New value of remainder of scheduled path
+102
+Last check time of flight pattern
+103
+Arrival time specified
+104
+Last check time of arrival time compliance
+105
+Next check time of arrival time compliance has passed
+106
+Last check time of fuel constraints
+107
+Next check time of fuel constraints has passed
+108
+Fly without fuel warnings
+109
+Fuel constraints check should be performed
+110
+Landing at closed base/landing strip check should be performed
+111
+Last check time of UAV tracking target
+112
+Next check time for UAV tracking target has passed
+113
+UAV tracking target check should be performed
+114
+Update remainder of scheduled path
+115
+Update the "remainder of scheduled path" value in the formation's memory for the specified job ID. If the formation has an applicable operation - the flight path on which "new threat zone on monitored flight path" alerts will be received is also updated accordingly.
+116
+The ID of the job (of a scheduled flight along a path) for which the update will be performed.
+117
+Threat zone monitored path should be updated
+118
+Scheduled flight along a path
+119
+Flight along a path that does not necessarily start at the current location. If an arrival time is specified - the flight speed will be adjusted / waiting in the air will be performed to ensure arrival at the end of the path at the required time.
+120
+Path
+121
+If specified - the formation adjusts its flight speed within the possible limits in order to meet the required time.
+122
+Ground speed
+123
+The flight speed relative to the ground in knots, for the duration of the flight on the path. At the end of the execution, the formation returns to its typical flight speed. If no speed is specified - the flight will be performed at the typical flight speed for the platform type.
+124
+Flight pattern
+125
+The flight pattern, for the duration of the flight on the path. At the end of the execution, the formation returns to the typical flight pattern for the platform type. If no pattern is specified - the flight will be performed in the typical flight pattern.
+126
+Anchor event
+127
+1. General definitions
+- The "actual speed" is the specified "ground speed" - if specified, otherwise - the typical flight speed (tactical function) for the formation.
+- The "actual flight pattern" is the specified "flight pattern" - if specified, otherwise if the formation is landed (tactical function) - "takeoff", otherwise - "cruise".
+- The formation is considered to have "not yet performed first takeoff" if the value of formation has performed first takeoff (tactical function) for it is 'no'.
+- The value "takeoff required" is 'yes' if the formation is landed (tactical function).
+- The "base path" is the "flight path for threat zone monitoring" if there is a new threat zone on the flight path, otherwise it is the specified path.
+
+2. How to calculate the "actual path"
+- The "intercept target point" is the closest point to the formation on the specified "path".
+- "Direct intercept possible" if the formation is allowed to intercept a path directly (tactical function) based on the "intercept target point".
+- The "turning radius" is the turning radius (nautical miles) (tactical function) of the formation at the "actual speed".
+- The "direct intercept path" is a conditional intercept path (tactical function) from the current location and direction of the formation to the specified "path", based on the "turning radius".
+- The "indirect intercept path" is an operational air path from the current vector (tactical function) of the formation to the "intercept target point", with a "landing" value of 'no', "straight line" - 'no', "speed" - the "actual speed".
+- The "intercept path" is the "direct intercept path" - if "direct intercept is possible", otherwise it is the "indirect intercept path".
+- The "intercept point" is the last point of the "intercept path".
+- The "target path" is the final segment of the specified "path", starting from the "intercept point".
+- The "path without threat zone avoidance" is determined as follows:
+If "takeoff is required" and the current location of the formation is equal to the start point of the specified "path" - it is the specified "path",
+otherwise - it is a glued air path (tactical function) from the "intercept path" and the "target path" based on the "turning radius".
+- The "path including threat zone avoidance" is based on threat zone avoidance for an existing path (tactical function) on the "path without threat zone avoidance".
+- The "actual path" is determined as follows:
+If "there is a new threat zone on the flight path" (an indication in the permanent memory that was turned on by the mission/unit response rule "response to a new threat zone on a monitored flight path") - it is the "path including threat zone avoidance", otherwise it is the "path without threat zone avoidance".
+
+3. If "takeoff is required", perform:
+
+a. If the executed mission order value (atomic function) of the formation is not empty and also (the formation "has not yet performed first takeoff" or the value of the permanent memory note "send takeoff report (C2)" is 'yes') - send a takeoff report to the C2 system and set the value of the permanent memory note "send takeoff report (C2)" to 'no'.
+Explanation: The permanent memory note "send takeoff report (C2)" is shared by this command and the "fly to land" command. The mechanism is intended to prevent sending takeoff reports to the C2 system following "occasional" landings and takeoffs - that were not planned in advance in the C2 system.
+
+b. If the value of the permanent memory note "first takeoff point" is empty - set it to the current location with the name of the nearby base - if there is one.
+
+c. Set the value of the permanent memory note "last takeoff time" to the current time value, for use by the "check flight pattern" response rule.
+
+4. If "there is a new threat zone on the flight path" and the "path including threat zone avoidance" is different from the "path without threat zone avoidance" - send a warning message to the formation. If the path has been significantly extended as a result of avoiding the threat zones - the message requires handling.
+
+5. Perform "set flight characteristics" (tactical) for the purpose of setting the (desired) speed to the "actual speed" and the "flight pattern" to the "actual flight pattern".
+
+6. Set the "there is a new threat zone on the flight path" indication in the formation's permanent memory to 'no'.
+
+7. Perform "update flight path for threat zone monitoring" to the "actual path".
+
+8. Perform "flight along a path (atomic)" on the "actual path" with a "land on arrival" value equal to the specified "land on arrival" value.
+
+9. Perform "update flight path for threat zone monitoring" to an empty path (no need for monitoring).
+
+10. At the beginning and end of the execution: perform the "set mission instructions (atomic)" command with a "full power flight authorized" value of 'no'.
+128
+Turn off "full power flight authorized"
+129
+No new threat zone on the flight path
+130
+"Takeoff required" and the "first takeoff point" value is empty.
+131
+Takeoff required
+132
+The actual path has changed as a result of avoiding the new threat zone
+and the path extension is significant
+133
+The path has been significantly extended as a result of a new threat zone. Possible effects on the mission should be examined.
+134
+The actual path has changed as a result of avoiding the new threat zone
+and the path extension is not significant
+135
+The path has been insignificantly extended (less than
+136
+miles) as a result of a new threat zone.
+137
+Delete indication of a new threat zone on the flight path
+138
+Initialize threat zone monitored path
+139
+The actual flight
+140
+Delete threat zone monitored path
+141
+Significant path extension (in nautical miles)
+142
+Actual speed
+143
+Has not yet performed first takeoff
+144
+There is a new threat zone on the flight path
+145
+Base path
+146
+Current direction
+147
+Intercept target point
+148
+Direct intercept possible
+149
+Turning radius
+150
+Direct intercept path
+151
+Indirect intercept path
+152
+Intercept path
+153
+Intercept point
+154
+The intercept point is at the beginning (which is also the end) of a circular path
+155
+Target path
+156
+Path without threat zone avoidance
+157
+Path including threat zone avoidance
+158
+Actual path
+159
+The actual path has changed as a result of avoiding the new threat zone
+160
+The path extension as a result of avoiding threat zones is significant
+161
+Operation ID
+162
+Nearby base
+163
+Takeoff location plus name of nearby base (if any)
+164
+Anchor event specified
+165
+Response to the start of a calculation cycle
+166
+Activate each of the other response rules at its required frequency.
+167
+Distribute events for periodic checking of compliance with required arrival time and updating the flight pattern
+168
+Check arrival time compliance
+169
+Adjust flight speed and perform holding pattern in the air as needed, as required to meet the arrival time.
+170
+The formation is landed or there is no remaining flight path or the formation is accelerating after takeoff or decelerating before landing
+171
+The absolute arrival time gap is zero
+172
+The required arrival time has not yet passed and the required speed for on-time arrival is in the range between the minimum practical speed and the maximum authorized speed
+173
+Set the desired flight speed to the required speed for on-time arrival
+174
+Delay expected
+175
+Gaining time by a minimum orbit will cause a delay
+176
+Set the desired flight speed to the higher of the minimum physical speed and the required speed for on-time arrival
+177
+Orbit to gain time (the difference between the required flight duration for on-time arrival and the remaining flight duration at typical speed)
+178
+Start of deceleration distance before landing (nautical miles)
+179
+End of acceleration distance after takeoff (nautical miles)
+180
+Flight path we have passed ("tail")
+181
+Length of flight path we have passed (meters)
+182
+Length of flight path we have passed (nautical miles)
+183
+Accelerating after takeoff
+184
+Remaining flight path
+185
+Length of remaining flight path (meters)
+186
+Slowing down before landing
+187
+Expected arrival time
+188
+Absolute arrival time gap
+189
+The required arrival time has already passed
+190
+Minimum practical speed (knots)
+191
+Minimum time gain in an orbit
+192
+Remaining flight duration at maximum authorized speed
+193
+Minimum physical speed (knots)
+194
+Typical speed (knots)
+195
+Remaining flight duration at typical speed
+196
+Required time gain in an orbit
+197
+Check flight pattern
+198
+Change the flight pattern from 'takeoff' to 'cruise after takeoff' and from 'cruise' to 'approach for landing' before landing.
+199
+The formation is landed or the current flight pattern is 'approach for landing'
+200
+The specified "land on arrival" value is 'yes' and also the distance to the end of the "actual path" does not exceed the "start of approach for landing distance"
+201
+Set the flight pattern to 'approach for landing' and set the "mission execution state" to "orbit for landing"
+202
+The current flight pattern is 'takeoff' and also the time elapsed since the "last takeoff time" is not less than the "delay for transition to cruise pattern"
+203
+If the "last takeoff time" value is empty (may happen in debug situations) - the formation is required to be in the "cruise" pattern
+204
+Set the flight pattern to 'cruise'
+205
+Delay for transition to cruise pattern
+206
+Start of approach for landing distance (miles)
+207
+Current flight pattern
+208
+The distance to the end of the "actual path"
+209
+Last takeoff time
+210
+Response to a new threat zone on a monitored flight path
+211
+Save a suitable indication in the formation's memory (if it considers threat zones).
+212
+The formation considers threat zones
+213
+Remember "new threat zone on monitored flight path" indication
+214
+The minimum time that can be gained/wasted by one orbit is the duration of a circular orbit at the minimum turning radius, at the maximum physical speed (although in reality such an orbit would cause an unbearable g-force on the pilots).
+215
+Air unit
+216
+The maximum gap between the required arrival time and the actual expected arrival time that is considered tolerable, i.e. does not require a response or an alert.
+217
+Value of "remainder of scheduled path" as stored in the formation's memory for the job ID of the "scheduled flight along a path" command. This is the remaining part of the flight path - on which to fly later in the execution of the command.
+218
+Formation
+219
+Arrival time check required
+220
+This event is sent by a formation to itself as part of executing a scheduled flight along a path, in order to cause a check of the expected arrival time at the current flight speed versus the required arrival time, and to perform an appropriate response.
+221
+Flight pattern check required
+222
+This event is sent by a formation to itself as part of executing a scheduled flight along a path, in order to cause a check of the current flight pattern and update it if necessary.
+223
+Fuel constraints check required
+224
+This event is sent by a formation to itself as part of executing a scheduled flight along a path, in order to cause a check of fuel constraints and send alerts if necessary.
+225
+UAV tracking target check required
+226
+This event is sent by a UAV to itself as part of executing a scheduled flight along a path, in order to cause a check of the location of the target being tracked and to change the orbit path accordingly.
+227
+Fly to point
+228
+Fly to a point, including choosing a path according to the traffic routes relevant to the platform type. On arrival, it is possible to wait, land or end (continue to the next command).
+229
+Point
+230
+What to do on arrival at the point.
+231
+Straight line to point
+232
+Whether to fly to the destination in a straight line, ignoring traffic route constraints.
+233
+1. If "straight line to point" is specified and also "land on arrival" is specified
+Then:
+a. "Full operational path to point" is "operational air path from current vector" (tactical function) to the specified "point", with a "straight line" value of 'no'.
+b. "Base control circle" is a circle whose center is at the specified "point" and its radius is "base control radius (CTR)" (tactical function).
+c. "Approach start point" is the last intersection point (hint: the first on the reverse path) of the "full operational path to point" with the "base control circle"
+d. If "approach start point" is empty (meaning the formation is inside the circle) - the "actual path" is the "full operational path to point", otherwise - find the "actual path" as follows:
+- "Path to start of approach" is "operational air path from current vector" (tactical function) to the "approach start point", with a "straight line" value of 'yes'.
+- "Approach for landing path" is the final part of the "full operational path to point" - from the "approach start point" to its end.
+- The "actual path" is a concatenation of the "path to start of approach" and the "approach for landing path", on which (on the concatenation) the "round turns for angular path" algorithm is applied, in order to round the connection between the two paths.
+Explanation: The traffic rules that apply within the "base control circle" on landing, override the "straight line to point" instruction.
+
+Otherwise,
+The "actual path" is an "operational air path from current vector" (tactical function) to the specified "point" at the typical speed, where the "straight line" value passed to the function is according to the specified "straight line to point" value.
+
+2. "Already there" = 'yes' if the formation's location is equal to the specified "point" and the specified "land on arrival" value is equal to the "landed formation" value (tactical function).
+
+3. If "already there" = 'no':
+Perform "scheduled flight along a path" on the "actual path", with the specified "arrival time".
+234
+Typical turning radius
+235
+Full operational path to point
+236
+Base control radius (in meters)
+237
+Base control circle
+238
+Approach start point
+239
+Approach start point is empty
+240
+Path to start of approach
+241
+Approach for landing path
+242
+Actual path
+243
+The formation is landed
+244
+Already there
+245
+Cyclic flight along a path
+246
+Fly along a base path cyclically, according to the specified return mode, including intercepting the cyclic path as required.
+247
+Base path
+248
+The path on the basis of which the actual cyclic flight path should be determined - which is required to be circular.
+249
+Return on the path
+250
+Orbit radius
+251
+The turning radius (in nautical miles) to be used in case the "return on path mode" is "orbit the path". If not specified - the turning radius is derived from the flight speed.
+252
+1. Definitions:
+- The "actual speed" is the specified "ground speed" - if specified, otherwise - the typical flight speed (tactical function) for the formation.
+- "Turning radius" is the turning radius (nautical miles) (tactical function) of the formation at the "actual speed".
+
+In the first iteration only:
+2. Calculate the "cyclic flight path for execution" based on the current direction and location of the formation relative to the actual cyclic flight path (as derived from the specified "base path" and "return on path" mode).
+
+If the "return on path" mode is "orbit the path":
+- The "actual orbit radius" is the "orbit radius", otherwise - it is the "turning radius".
+- "Orbit intercept path" and "opposite orbit intercept path" are conditional intercept paths (tactical function) from the current location and direction of the formation to the "orbit path" and "opposite orbit path" respectively.
+- If the "orbit intercept path" is not longer than the "opposite orbit intercept path", the "actual orbit path" is the "orbit path", otherwise it is the "opposite orbit path".
+
+3. If the formation is not located on the "cyclic flight path for execution":
+- Perform "set mission execution state" to "en route".
+- Perform "scheduled flight along a path" on the "intercept path" with the specified "ground speed" and "flight pattern".
+The "intercept path" is a conditional intercept path (tactical function) from the current location and direction of the formation to the "cyclic flight path for execution".
+
+4. Perform "set mission execution state" to "stabilized".
+
+5. If the formation is located on the path, the "actual cyclic flight path" is the "cyclic flight path for execution"
+Otherwise it is the "intercepted cyclic flight path".
+The "intercepted cyclic flight path" is the "cyclic flight path for execution" that starts and ends at the "intercept point".
+
+In each iteration:
+6. Perform "scheduled flight along a path" on the "actual cyclic flight path" with the specified "ground speed" and "flight pattern".
+253
+In the first iteration:
+If the formation is not located on the cyclic path: scheduled flight along the intercept path
+Remember polyline (the cyclic path)
+Flight along a path
+254
+First iteration, and intercept to the cyclic path is required
+255
+Turning radius (in miles)
+256
+Actual orbit radius (in miles)
+257
+Actual 'outbound leg on path' path
+258
+'Out-and-back on path' path
+259
+Orbit path
+260
+Opposite orbit path
+261
+Orbit intercept path
+262
+Opposite orbit intercept path
+263
+Actual orbit intercept path
+264
+'Orbit path' actual path
+265
+Cyclic flight path for execution
+266
+Actual intercept path
+267
+Intercepted cyclic flight path
+268
+Actual cyclic flight path
+269
+End of sortie
+270
+Perform end of sortie procedure which includes driving to the squadron, organizing for debriefing and debriefing.
+271
+0. If the formation is in the air - end the execution of the command.
+
+1. Perform "set mission execution state" to change the "mission execution state" to "taxiing to shelter".
+
+2. Wait 5 minutes.
+
+3. Perform "set mission execution state" to change the "mission execution state" to "driving to squadron".
+
+4. Wait 10 minutes.
+
+5. Perform "set mission execution state" to change the "mission execution state" to "organizing for debriefing".
+
+6. Wait 30 minutes.
+
+7. Perform "set mission execution state" to change the "mission execution state" to "debriefing".
+
+8. Wait 30 minutes.
+
+9. Perform "set mission execution state" to change the "mission execution state" to "finished".
+
+10. Wait indefinitely (in order to keep the flight plan in an active state).
+272
+The formation is in the air
+273
+Send takeoff/landing report
+274
+Send a report on the takeoff/landing of a formation to the C2 system at the current time.
+275
+Send takeoff report
+276
+Send takeoff report
+277
+Send landing report
+278
+Nearby base ID
+279
+Nearby landing strip ID
+280
+Actual nearby landing strip ID
+281
+Takeoff/landing point
+282
+Send anchor alerts
+283
+Send messages to the executing formation if necessary: if the formation's anchor time (from the mission instructions) is empty or if the anchor event from the mission instructions (which may in particular be empty) does not match the expected/relevant anchor events for the command.
+284
+Command name
+285
+Expected anchor event 1
+286
+Expected anchor event 2
+287
+1. The formation's anchor event is considered "matching" if it matches the specified "expected anchor event 1" (tactical function - matching anchor events) or "expected anchor event 2" - if specified.
+
+2. If the formation's anchor time is empty - send a message to the formation: "No anchor time is defined in the mission instructions. ["Command name"] will be executed without an arrival time constraint."
+
+3. If the formation's anchor time is not empty and the formation's anchor event is not "matching" - send a message to the formation:
+"The anchor event in the mission instructions (["Display name of the formation's anchor event - if not empty"] | [empty]) does not match the ["Command name"] command. The timing will be performed according to "[Display name of "Expected anchor event 1"]"."
+288
+Send messages
+289
+No anchor time is defined in the mission instructions.
+290
+will be executed without an arrival time constraint.
+291
+The anchor event in the mission instructions
+292
+empty
+293
+does not match the command
+294
+The timing will be performed according to
+295
+Matching anchor event
+296
+Set send takeoff report (C2)
+297
+Set the "send takeoff report (C2)" value in the permanent memory of the executing formation.
+298
+Send takeoff report (C2)
+299
+Send information message about landing
+300
+Send an information message describing the landing of a formation.
+301
+Landing site name
+302
+Ends sortie
+303
+Refueling performed
+304
+Waiting time on the ground
+305
+The formation has landed [at <landing point name if it exists>].
+[Ends sortie] | [in[refueling and] waiting until <end of waiting time>]
+306
+The formation has landed
+307
+in refueling and waiting
+308
+waiting
+309
+indefinitely
+310
+until
+311
+Set full power flight authorized
+312
+Set the "full power flight authorized" value in the permanent memory of the executing formation.
+313
+Full power flight authorized
+314
+Flight along a path scheduled to its end
+315
+A flight along a path command scheduled to the end of the path (and not to the start of the flight on it) if the specified "intercept path from its beginning" value is 'no' and also the specified "return on path" value is empty.
+316
+Intercept path from its beginning
+317
+Set flight characteristics
+318
+Set the desired flight altitude, desired speed and flight pattern of the formation.
+319
+Set [altitude to "altitude"] [speed to "speed"]
+[flight pattern to "flight pattern"]
+320
+Only components for which a value was specified appear.
+321
+Set
+322
+altitude to
+323
+speed to
+324
+flight pattern to
+325
+Altitude
+326
+The desired absolute flight altitude (above sea level) in thousands of feet. If no value is specified - the desired flight altitude remains unchanged.
+327
+The specified altitude exceeds the formation's flight altitude limits.
+328
+Speed
+329
+The desired flight speed relative to the ground - in knots. If not specified - the desired flight speed remains unchanged.
+330
+The specified speed exceeds the formation's flight speed limits.
+331
+The flight pattern in which to fly. If not specified - the current flight pattern is maintained.
+332
+At least one of the parameters must be filled.
+333
+Holding pattern in the air
+334
+Wait for a defined period of time - according to duration or according to end time, or for an unlimited duration - if no waiting time is specified.
+335
+Holding pattern in the air [on path [name of "holding path"]] [until hh:mm] | [for hh:mm]
+336
+"on path..." appears only if "holding path" is specified.
+until hh:mm appears only if "end time" is specified.
+for hh:mm appears only if "wait duration" is specified.
+337
+on path
+338
+for
+339
+until
+340
+Wait duration
+341
+End time
+342
+End time or wait duration can be filled, but not both
+343
+Holding path
+344
+The path on which to wait. If not specified - the waiting will be performed at the current location.
+345
+1. Definitions:
+
+a. An "arbitrary holding path" is a path in the shape of a "popsicle stick" where:
+     - The radius of the arcs is the turning radius at the typical flight speed for the platform type.
+     - The length of the straight segment is equal to the radius of the arcs multiplied by 'turning radius to straight leg multiplier'.
+     - The "popsicle stick" is located so that the formation (at its current location and direction) is at the end of its left straight segment,
+    at the point where it is supposed to start turning right on the upper arc.
+
+b. The "actual holding path" is the specified "holding path" - if it is not empty, otherwise - it is the straight line that forms the center spine of the "arbitrary holding path".
+
+2. Save the "actual end time" in the formation's memory, which is:
+     - The specified "end time" - if it is not empty, otherwise
+     - The current time value plus the specified "wait duration" - if it is not empty, otherwise
+     - An empty time value.
+
+3. If a holding path is specified and the formation is not authorized to intercept it at its start point (tactical func. "formation is authorized to intercept path directly"):
+- Perform "set mission execution state" to "en route".
+- Perform flight to a point to the start of the specified holding path.
+
+4. Perform "cyclic flight along a path" on the "actual holding path" with a "return on path" value of "orbit the path".
+
+4. If the "actual end time" is not empty - the flight should be stopped when the end time is reached.
+346
+The "actual end time" has already passed
+347
+Remember time
+If "holding path" is specified and the formation is authorized to intercept it at the start point: fly to the start point of the path
+Cyclic flight along a path
+348
+"Holding path" is specified and the formation is not authorized to intercept it
+349
+Turning radius to straight leg multiplier
+350
+Turning radius at typical speed (in miles)
+351
+Turning radius (in meters)
+352
+Current direction of movement
+353
+The center spine of the arbitrary holding path
+354
+Actual holding path
+355
+Fly to direction
+356
+Perform a turn and fly in a given direction.
+357
+Fly to direction ["direction"]
+358
+degrees
+359
+Direction
+360
+1. Perform "set mission execution state" to "en route".
+
+2. Perform a scheduled flight along a path composed of:
+- The shorter of the two turning arcs to reach the required direction.
+- A straight leg of 'maximum flight range to direction' length in the required direction.
+361
+Maximum flight range to direction (in miles)
+362
+Maximum flight range to direction (in meters)
+363
+Turning radius
+364
+Whether to turn left
+365
+Left turn path
+366
+Right turn path
+367
+Actual turn path
+368
+Straight leg path
+369
+The full path
+370
+Arrival at sector
+371
+Arrival at a sector, including choosing a path according to the traffic routes relevant to the platform type.
+372
+Arrival at sector [name of "sector"] [at "arrival time" hh:mm] [(wait on arrival)]
+373
+Arrival time component appears only if "arrival time" is specified.
+Wait on arrival component appears only if "wait on arrival" = 'yes' is specified.
+374
+at
+375
+(wait on arrival)
+376
+Sector
+377
+The sector to arrive at. If no sector is specified - the sector will be inferred from "holding area" / "entry corridor".
+378
+The sector cannot be inferred as neither "entry corridor" nor "holding area" were specified.
+379
+Wait on arrival
+380
+Whether to wait after arriving at the sector.
+If no value is specified then:
+- If "holding area" is specified - waiting will be performed.
+- If "entry corridor" is specified - no waiting will be performed.
+- If neither is specified - waiting will be determined by the attack profile as defined in the timing instructions: in hunt - yes, in supplies - no.
+381
+A 'no' value for "wait on arrival" contradicts the specification of "holding area".
+382
+Holding area
+383
+If waiting on arrival is required and no holding area is specified - the holding area defined as preferred for the sector will be chosen.
+384
+A holding area belonging to the sector must be specified.
+385
+Entry corridor
+386
+The corridor through which the entry to the sector will be performed. If specified - no waiting is performed on arrival.
+If no entry corridor is specified and the sector must be entered (no waiting on arrival was specified and no holding area was specified) - the entry will be performed through the entry corridor defined as preferred for entry to the sector.
+387
+An entry corridor belonging to the sector must be specified. Do not specify an entry corridor when waiting on arrival is required or a "holding area" is specified.
+388
+Waiting on arrival is required = a 'yes' value was specified for "wait on arrival"
+389
+Is anchor
+390
+If 'yes' is specified then:
+If the anchor event (defined by the timing instructions) is "stabilization" or "circle" - the holding area must be reached at the anchor time.
+If the anchor event is "direction exit" - the end of the entry corridor (the direction exit point) must be reached at the anchor time.
+391
+A command should not be defined as an anchor when an arrival time is specified. An anchor command is timed only according to the anchor time defined in the timing instructions.
+392
+1. Definitions:
+- The "actual sector" is the specified sector or the sector implied by the specified "holding area" / "entry corridor".
+- The "actual holding route" is the "holding area" - if specified, otherwise - the "preferred route" (atomic function) for waiting in the "actual sector" (may be empty).
+- The "entry path" is the entry path (tactical function) to the center of the "actual sector" based on [the geometry of] the specified "actual entry corridor".
+- The "actual wait on arrival" value (yes/no) is determined as defined in the description of the "wait on arrival" parameter.
+- The "expected anchor event" is "stabilization" - if the "actual wait on arrival" value is 'yes', otherwise - "direction exit".
+- The "actual arrival time" (may be empty) is determined as follows: if "is anchor" is specified - 'yes' - it is the formation's anchor time, otherwise it is the specified "arrival time".
+
+2. If "is anchor" is specified - 'yes' - perform sending of anchor alerts with "arrival at sector" as "command name" and the "expected anchor event" as "expected anchor event 1".
+
+3. If the formation is not inside the actual sector, or if the "actual wait on arrival" value is 'yes' and the "actual holding route" is not empty, perform "set mission execution state" to "en route".
+
+4. If the "actual wait on arrival" value is 'yes' and the "actual holding route" is not empty - perform a flight to a point to the start point of the "actual holding route" with an "arrival time" equal to the "actual arrival time".
+
+5. If the formation is not inside the sector and also the "actual wait on arrival" value is 'no' (entry only) or (the "actual wait on arrival" value is 'yes' and also the "actual holding route" is empty) (entry and waiting):
+- The "arrival path" is an operational air path from the current vector (tactical function) to the start point of the "entry path".
+- The "shortened entry path" is the "entry path" without the part that passes inside [the polygon of] the "actual sector", except for the "excess entry range into the sector" from its beginning. Explanation: the point to be reached must be inside the sector and not on its perimeter.
+- The "full path" is a conditional threat zone avoiding air path (tactical function) based on the concatenation of the "arrival path" and the "shortened entry path".
+- Perform "scheduled flight along a path" on the "full path" with an "arrival time" equal to the "actual arrival time".
+
+6. If "wet run" and also the "actual wait on arrival" value is 'yes' - perform "holding pattern in the air" on [the geometry of] the "actual holding route" (may be empty).
+393
+If "is anchor" is specified - 'yes': send anchor alerts
+If the "actual wait on arrival" value is 'yes' and "actual holding route" is defined: fly to point
+Otherwise if the formation is not already inside the sector: fly along a path
+If "wet run" and also the "actual wait on arrival" value is 'yes': hold in the air.
+394
+"Is anchor" is specified - 'yes'
+395
+The formation is not inside the sector or the "actual wait on arrival" value is 'yes' and the "actual holding route" is not empty.
+396
+"Actual wait on arrival" value is 'yes' and "actual holding route" is not empty.
+397
+The formation is not inside the sector and also the "actual wait on arrival" value is 'no' or (the "actual wait on arrival" value is 'yes' and the "actual holding route" is empty)
+398
+The "actual wait on arrival" value is 'yes'
+399
+Actual sector
+400
+Actual holding route
+401
+Entry path
+402
+Actual wait on arrival
+403
+Expected anchor event
+404
+Actual arrival time
+405
+The formation is inside the sector
+406
+Start of holding route
+407
+Start of entry path
+408
+Arrival path
+409
+Excess entry range into the sector
+410
+Shortened entry path
+411
+Arrival at coordinate
+412
+Arrival at a coordinate, including choosing a path according to the traffic routes relevant to the platform type.
+413
+Arrival at coordinate [name of "coordinate"] [at "arrival time" hh:mm] [(wait on arrival)]
+414
+Coordinate
+415
+Whether to remain in a holding pattern after arriving at the coordinate.
+416
+Straight line to coordinate
+417
+Whether to fly to the coordinate in a straight line, ignoring traffic route constraints.
+418
+1. - Perform "set mission execution state" to "en route".
+
+2. Perform "fly to point" with the following parameters:
+- Point - the specified "coordinate".
+- Straight line to point - the specified "straight line to coordinate".
+- Arrival time - the specified "arrival time".
+
+3. If "wait on arrival" is specified - 'yes': perform "holding pattern in the air".
+419
+Fly to point
+If "wait on arrival" is specified: hold in the air
+420
+"Wait on arrival" is specified - 'yes'
+421
+Fly to land
+422
+Fly to the landing point, including choosing a path according to the traffic routes relevant to the platform type, and performing a landing at the end.
+423
+Fly to land at [name of base/landing strip/coordinate/first takeoff point]
+424
+Fly to land at
+425
+First takeoff point
+426
+Straight line to landing
+427
+Whether to fly to land in a straight line, ignoring traffic route constraints.
+428
+Landing base
+429
+If no parameter defining the landing point is entered, the implied landing point is the first takeoff point.
+430
+The formation is not capable of landing at this base as the maximum runway length at the base is too short for the platform type.
+431
+Landing strip
+432
+At most one parameter can be entered from among "landing base", "landing strip" and "landing coordinate".
+433
+Landing coordinate
+434
+Prevent C2 report
+435
+If 'yes' is specified - no landing report will be sent to the C2 system.
+436
+If specified - after landing, a wait will be performed for this duration or for the time required for ground refueling if specified - according to the longer of the two.
+If no value is specified and also no ground refueling is specified - an unlimited time wait will be performed, until the command is actively stopped.
+437
+Ground refueling
+438
+Whether to perform ground refueling.
+The command will end after refueling, unless a longer ground wait time than the refueling duration is specified.
+439
+0. Definitions
+- "Refueling duration" is equal to the full ground refueling duration (tactical function) typical for the air platform category.
+- "Refueling should be performed" if "ground refueling" is specified - 'yes' and also the current amount of "aircraft fuel (lbs)" in the formation is less than its typical standard amount.
+- "Actual wait duration" is equal to the greater of
+   + "Ground wait duration" - if specified, otherwise zero.
+   + "Refueling duration" - if "refueling should be performed", otherwise zero.
+
+
+1. Set the "actual landing point" to the actual landing location (tactical func.) with the specified parameter values.
+
+2. If the formation is landed (tactical func.) and the current location is equal to the "actual landing point" - finish (nothing needs to be done).
+
+3. Perform "set mission execution state" to "en route".
+
+4. Perform "fly to point" with the following parameters:
+- Point - the "landing point".
+- Land on arrival - 'yes'.
+- Straight line to point - the specified "straight line to landing".
+- Arrival time - the specified "arrival time".
+
+5. Perform the "set flight characteristics" command to change the flight pattern to "empty flight pattern".
+
+6. If the "executed mission order" value of the formation is not empty and "prevent C2 report" is specified - 'no':
+- Perform sending of a landing report to the C2 system.
+- Set the value of the memory note "send takeoff report (C2)" to 'yes' - in order to cause a takeoff report to be sent to the C2 system on the next takeoff (by a scheduled flight along a path command).
+
+7. Perform "send information message about landing".
+
+8. If "ground refueling" is specified - 'yes' - perform "initialize fuel constraints check".
+
+9. If "refueling should be performed":
+- Set (in advance) the amount of "aircraft fuel (lbs)" in the formation to the standard amount of "aircraft fuel (lbs)" typical for the platform type
+- Perform initialize fuel constraints check.
+
+9. Perform "set mission execution state" with a "mission execution state" value of an empty string.
+
+10. If "ground refueling should be performed":
+- Perform "set mission execution state" to "landed and refueling".
+- Wait for the "refueling wait duration".
+
+11. Perform "set mission execution state" to "landed and waiting".
+
+12. Wait for the "actual ground wait duration".
+
+13. If "ground wait duration" was not specified and also "ground refueling" was specified - 'no' and also the "actual landing point" is equal to the "first takeoff point" (tactical function) - perform "end of sortie".
+440
+Cannot perform flight to land as the landing point is not defined (was not explicitly defined and the formation has not performed its first takeoff).
+441
+The formation is landed and located at the actual landing point
+442
+Actual landing point
+443
+Actual landing point is not defined
+444
+The formation is located at the actual landing point
+445
+Refueling duration
+446
+Standard aircraft fuel quantity
+447
+Current aircraft fuel quantity
+448
+Ground refueling should be performed
+449
+Wait duration for refueling
+450
+Actual wait duration on the ground
+451
+Actual wait duration
+452
+Landing at the first takeoff point
+453
+Sortie should be ended
+454
+Whether to send C2 reports
+455
+Arrival at area
+456
+Arrival at an area according to the traffic routes relevant to the platform type.
+457
+Arrival at [center of] area [name of "area"] [at "arrival time" hh:mm] [(wait on arrival)]
+458
+The word "center of" appears only if "arrival at center of area" = 'yes' is specified.
+Arrival time component appears only if "arrival time" is specified.
+Wait on arrival component appears only if "wait on arrival" = 'yes' is specified.
+459
+Arrival at center of area
+460
+Area
+461
+The area to arrive at.
+462
+Whether to wait after arriving at the area.
+If no value is specified, waiting will be determined by the attack profile as defined in the timing instructions: in hunt - yes, in supplies - no.
+463
+Arrival at the center of the area
+464
+Whether to arrive at the center of the area or at its edges.
+If no value is specified, arrival at the center of the area will be performed in case waiting on arrival is to be performed.
+465
+If 'yes' is specified - the area must be reached at the anchor time.
+Note: if the anchor event is "delivery", "launch" or "impact" - the anchor command should be "attack cluster of targeting points" and not "arrival at area".
+466
+A command should not be defined as an anchor when an arrival time is specified. An anchor command is timed only according to the anchor time defined in the timing instructions.
+467
+1. Definitions:
+- The "actual arrival time" (may be empty) is determined as follows: if "is anchor" is specified - 'yes' - it is the formation's anchor time, otherwise it is the specified "arrival time".
+- "Actual wait on arrival" is set to 'yes' if the "wait on arrival" value is specified as 'yes' or
+   if no "wait on arrival" value is specified and the effective attack profile for the formation is "hunt".
+- "Actual arrival at center of area" is set to 'yes' if the "arrival at center of area" value is specified as 'yes' or
+   if no "arrival at center of area" value is specified and the "actual wait on arrival" value is 'yes'.
+- The "center of the area" is at the internal center point (context-free tactical function) of the polygon of the specified "area".
+- The "operational path" is an operational air path from the current vector (tactical function) to the "center of the area".
+- The "operational entry point" to the area is the intersection point of the "operational path" with the polygon of the specified "area".
+- The "expected anchor event" is "stabilization" if the "actual wait on arrival" value is 'yes', otherwise it is "direction exit".
+- "Path should be split" if "is anchor" is specified - 'yes', the "expected anchor event" is "direction exit", and also the "actual arrival time" is not empty.
+- The "path to the area" is the "operational path" if the "actual arrival at center of area" value is 'yes' and also the "path should be split" value is 'no',
+   otherwise it is a path to the "operational entry point".
+
+2. If "is anchor" is specified - 'yes' - perform sending of anchor alerts with "arrival at area" as "command name", and the "expected anchor event" as "expected anchor event 1".
+
+3. If the current location of the formation is not inside the polygon of the specified "area":
+a. Perform "set mission execution state" to "en route".
+b. Perform "scheduled flight along a path" on the "path to the area".
+c. If "path should be split" - perform "scheduled flight along a path" on a path from the entry point to the area to the center of the area.
+
+4. If "wet run" and also the "actual wait on arrival" value is 'yes' - perform holding pattern in the air.
+468
+If "is anchor" is specified: send anchor alerts
+If the formation is not inside the polygon of the "area": fly on a path to the area
+If the formation is not inside the polygon of the "area" and the path should be split: fly on a path to the center of the area
+If "wet run" and also waiting on arrival should be performed: hold in the air
+469
+"Is anchor" is specified - 'yes'
+470
+The formation is not inside the polygon of the "area"
+471
+The formation is not inside the polygon of the "area" and the path should be split
+472
+Anchor time
+473
+Actual arrival time
+474
+The attack profile is "hunt"
+475
+Actual arrival at center of area
+476
+Center of the area
+477
+Operational path
+478
+Operational entry point
+479
+Target point
+480
+Direction exit
+481
+Path should be split
+482
+Path to the operational entry point
+483
+Path to the area
+484
+Path from the operational entry point to the center of the area
+485
+Fly along a path
+486
+Fly along a path that does not necessarily start at the current location, while adjusting the flight speed to arrive at the end of the path at the defined time.
+487
+Fly along a path [name of the path]:
+[display name of "return on path"] [from its beginning]
+[[starting at] | [ending at] hh:mm]
+488
+[display name of "return on path"] will appear only if the specified "return on path" value is not empty.
+[from its beginning] will appear only if "intercept path from its beginning" is specified - 'yes'.
+[[starting at] | [ending at] hh:mm] will appear only if a value is specified for "arrival time":
+[ending at] will appear if the flight along a path command is scheduled to its end (tactical function), otherwise [starting at...] will appear.
+489
+from its beginning
+490
+ending at
+491
+starting at
+492
+Reverse path
+493
+If 'yes' is specified - fly on the path in the opposite direction: from its end to its beginning.
+494
+Whether to get on the path from its beginning or at the closest point.
+495
+If specified - a round trip flight will be performed along the path according to the selected return mode.
+496
+Cannot perform return on a path for a path that intersects itself.
+497
+If specified - the formation adjusts its flight speed within the possible limits in order to meet the required time.
+If a "return on path" mode or "intercept path from its beginning" 'yes' is specified - this is the time at which to start flying on the path, otherwise - it is the time at which to arrive at the end of the path.
+498
+The flight altitude in thousands of feet, for the duration of the flight on the path. This altitude will also be maintained later, after the command ends.
+If not specified - the current flight altitude is maintained.
+499
+The altitude exceeds the possible altitude range for the platform type.
+500
+The flight speed relative to the ground in knots, for the duration of the flight on the path. At the end of the execution, the formation returns to its typical flight speed.
+If no speed is specified - the flight will be performed at the typical speed.
+501
+The speed exceeds the possible speed range for the platform type.
+502
+If 'yes' is specified - the "arrival time" is set to the anchor time defined in the mission instructions.
+Note: if the anchor event is "delivery", "launch" or "impact" - the anchor command should be "attack cluster of targeting points" and not "fly along a path".
+503
+A command should not be defined as an anchor when an "arrival time" is specified. An anchor command is timed only according to the anchor time defined in the timing instructions.
+504
+1. General definitions
+- "Base path" is the reverse of the specified "path" - if "reverse path" is specified - 'yes', otherwise it is the specified "path".
+- "Start point" is the start point of the "base path" - if "intercept path from its beginning" is specified - 'yes', otherwise it is the point on the "base path" closest to the current location of the formation.
+- The "timing to the end of the path" value is 'yes' if the flight along a path command is scheduled to its end (tactical function).
+- The "expected anchor event" is "direction exit" - if "timing to the end of the path", otherwise - "stabilization".
+- The "actual arrival time" (may be empty) is the formation's anchor time - if "is anchor" is specified - 'yes', otherwise it is the specified "arrival time".
+
+2. How to calculate the "actual path"
+- The "raw path" is the final segment of the "base path", starting from the "start point".
+- The "origin sector" (may be empty) is the containing sector (atomic function) of the "start point".
+- The "sector boundaries" value is determined as follows: if the "origin sector" is not empty and the entire "raw path" is inside (atomic function) the "origin sector" polygon - it is the "origin sector" polygon, otherwise - an empty polygon.
+- The "raw path avoiding threat zones" is an air path avoiding threat zones (tactical function) based on the "raw path" and the "sector boundaries".
+- The "actual speed" is the specified "ground speed" - if specified, otherwise - the typical speed of the formation.
+- The "turning radius" is the turning radius (nautical miles) (tactical function) of the formation at the "actual speed".
+- The "actual path" is a rounded turns path (atomic function) based on the "raw path avoiding threat zones" and the "turning radius".
+
+3. If "is anchor" is specified - 'yes' - perform sending of anchor alerts with "fly along a path" as "command name" and the "expected anchor event" as "expected anchor event 1".
+
+4. If a non-empty "altitude" value is specified - perform set flight characteristics (atomic) with the specified "altitude" value.
+
+5. If the "timing to the end of the path" value is 'no' or the specified "return on path" value is empty - perform "set mission execution state" to "en route".
+
+6. If the "timing to the end of the path" value is 'no' - perform a flight to a point to the "start point" with the "actual arrival time" and with the specified "ground speed" and "flight pattern" values.
+
+7. If the specified "return on path" value is empty - then perform a scheduled flight along a path on the "actual path" with the "actual arrival time" as "arrival time" and with the specified "ground speed" and "flight pattern" values,
+otherwise - perform a cyclic flight along a path on the "base path" with the specified "return on path" value and with the specified "ground speed" and "flight pattern" values.
+505
+If "is anchor" is specified - 'yes': send anchor alerts
+If "altitude" is specified: set flight characteristics
+If "timing to the end of the path" value is 'no': fly to point
+
+If "return on path" is empty: scheduled flight along a path
+Otherwise: cyclic flight along a path
+506
+"Is anchor" - 'yes'
+507
+"Altitude" is specified
+508
+"Timing to the end of the path" value is 'no'
+509
+"Return on path" value is empty
+510
+"Return on path" value is not empty
+511
+Start point
+512
+Timing to the end of the path
+513
+Arrival time to the end of the path
+514
+Raw path
+515
+Origin sector
+516
+Sector boundaries
+517
+Raw path avoiding threat zones
+518
+Move anchor and planned first takeoff time
+519
+Move the anchor time (if defined for the formation) and the planned first takeoff time (if defined for the formation) by the specified change rate.
+520
+Change rate
+521
+Perform "set mission instructions (atomic)" to move the anchor time (if defined for the formation) and the planned first takeoff time (if defined for the formation) by the specified "change rate".
+522
+Response to simulation time shift
+523
+In response to an arbitrary shift of the simulation time, a corresponding shift of the planned first takeoff time and the formation's anchor time is performed.
+524
+Move anchor and planned first takeoff time by the change rate
+525
+Response to lack of main command
+526
+If the formation is in the air - an unlimited time wait command is performed, otherwise (on the ground) - nothing is performed.
+527
+The unit is in the air
+528
+Typical flight speed (in knots)
+529
+The typical flight speed (in knots) for the specified platform type.
+530
+Air platform type
+531
+The typical flight speed (in knots) for the platform type of the specified air unit.
+532
+Minimum flight speed (in knots)
+533
+The minimum flight speed (in knots) typical for the platform type of the specified air unit.
+534
+Minimum practical flight speed (in knots)
+535
+The minimum flight speed (in knots) typical for the platform type of the specified air unit, which is still considered practical - i.e. the (increased) fuel consumption at it is still considered tolerable.
+Explanation: fuel consumption at the minimum possible flight speed is very high, due to the need to compensate for loss of lift with engine power.
+536
+The minimum speed plus 60% of the difference between it and the typical speed.
+537
+Maximum flight speed (in knots)
+538
+The maximum flight speed (in knots) typical for the platform type of the specified air unit.
+539
+Maximum practical flight speed (in knots)
+540
+The maximum flight speed (in knots) typical for the platform type of the specified air unit, which is still considered practical - i.e. the (increased) fuel consumption at it is still considered tolerable.
+541
+The maximum speed minus 60% of the difference between it and the typical speed.
+542
+Maximum authorized flight speed (in knots)
+543
+The maximum authorized flight speed (in knots) is the maximum practical flight speed (tactical function), unless the formation is authorized for full power flight (according to the execution policy) - in which case it is the "physical" maximum possible flight speed.
+544
+Applicable acceleration (in knots per second)
+545
+The applicable acceleration (in knots per second) for the specified air unit to change its flight speed from the current speed to the specified target speed.
+If the target speed is less than the current speed - the applicable acceleration is negative (deceleration).
+546
+Target speed (knots)
+547
+Speed change duration
+548
+The time required to change the flight speed of the specified air unit to the specified target speed.
+549
+Target speed (knots)
+550
+Speed change distance
+551
+The distance (in nautical miles) that the specified air unit travels during the time required to change its flight speed from its current value to the specified target speed.
+552
+To the distance traveled during the speed change, a small addition is added based on half the marginal rate of change of the speed (atomic function).
+This addition is intended to compensate for the fact that the speed change precedes the movement in each calculation cycle.
+553
+Time according to acceleration, speed and distance
+554
+The time required to travel the specified distance (in nautical miles) while changing speed at the specified acceleration rate, when starting at the specified initial speed (in knots).
+Note: when the acceleration is negative (deceleration) the solution is not guaranteed. In case there is no solution - a very long time period is returned (9,999,999 seconds).
+555
+Acceleration (knots per second)
+556
+Initial speed (knots)
+557
+Distance (nautical miles)
+558
+Flight time of a formation according to speed and distance
+559
+The time required for the specified air unit to travel the specified distance (in nautical miles) at the specified target speed (in knots), taking into account its current flight speed.
+560
+Adding half the marginal rate of change of the speed (atomic function) when calling the "time according to acceleration, speed and distance" tactical function is intended to compensate for the fact that the speed change precedes the movement in each calculation cycle.
+561
+Turn rate (degrees per second)
+562
+The turn rate (in degrees per second) typical for the platform type of the specified air unit.
+563
+Minimum turning radius (nautical miles)
+564
+The minimum turning radius (in nautical miles) of the specified air unit, which is derived from the typical turn rate for its platform type and the minimum practical flight speed (tactical function).
+565
+Typical turning radius (nautical miles)
+566
+The typical turning radius (in nautical miles) of the specified air unit, which is derived from the turn rate and the typical flight speed for its platform type.
+567
+Turning radius (nautical miles)
+568
+The turning radius (in nautical miles) of the specified air unit at the specified speed (in knots), which is derived from the typical turn rate for its platform type.
+569
+Speed (knots)
+570
+The speed in meters per second divided by the turn rate in degrees per second gives the length of the turning arc of one degree in meters.
+This should be multiplied by 180 and divided by pi to get the radius in meters, and finally converted to nautical miles.
+571
+Minimum flight altitude (thousands of feet)
+572
+The minimum flight altitude in thousands of feet: approximately the altitude of the Dead Sea.
+573
+Maximum flight altitude (thousands of feet)
+574
+The maximum flight altitude (in thousands of feet) typical for the platform type of the specified air unit.
+575
+Minimum flight altitude above ground level (thousands of feet)
+576
+The minimum flight altitude above ground level (in thousands of feet) typical for the platform type of the specified air unit.
+577
+Climb rate (thousands of feet)
+578
+The climb rate (in thousands of feet per minute) typical for the platform type of the specified air unit.
+579
+The descent rate (in thousands of feet per minute) typical for the platform type of the specified air unit.
+580
+Applicable altitude change rate (thousands of feet per minute)
+581
+The applicable altitude change rate (in thousands of feet per minute) for the specified air unit to change its flight altitude from the current altitude to the specified target altitude.
+If the target altitude is less than the current altitude - the applicable altitude change rate is negative (descent).
+582
+Target altitude (thousands of feet)
+583
+Altitude change duration
+584
+The time required to change the flight altitude of the specified air unit to the specified target altitude.
+585
+Target altitude (thousands of feet)
+586
+Typical flight altitude (thousands of feet)
+587
+The flight altitude (in thousands of feet) typical for the platform type of the specified air unit.
+588
+Required runway length (in meters)
+589
+The runway length required for takeoff/landing of the specified air unit.
+590
+Full ground refueling duration
+591
+The duration of a full ground refueling (from zero to one hundred percent) of a formation belonging to the specified air platform category.
+592
+Air platform category
+593
+For helicopters: 30 minutes, for all others: 45 minutes.
+594
+Chained entry path
+595
+Entry path to the specified sector (geometry) for the specified formation. The returned path includes the following segments:
+a. The specified entry route (geometry)
+b. If the end point of the entry route is not inside the sector - a linking segment connecting it to the closest point to the end of the entry route on the sector's perimeter.
+c. The flight segment inside the sector to the specified target point, including threat zone avoidance taking into account the sector's limitations.
+596
+Entry route (geometry)
+597
+Sector (geometry)
+598
+Target
+599
+Entry path
+600
+Path leading through the actual entry route (see below) to the specified containing sector to the specified target point (should be inside the containing sector), while avoiding threat zones inside the sector (meaning no threat zone avoidance on the actual entry route).
+The actual entry route is the specified entry route (geometry) - if it is not empty, otherwise - the preferred entry route of the specified containing sector.
+If the specified containing sector is empty or the actual entry route is empty - the returned path degenerates to only the target point.
+601
+Containing sector
+602
+Path entry point to sector
+603
+The entry point of the specified path to the applicable sector for the platform type and army of the specified formation.
+If the path does not end inside a sector - the end point of the specified path is returned.
+604
+Chained exit path
+605
+Exit path from the specified sector (geometry) for the specified formation. The returned path includes the following segments:
+a. The flight segment inside the sector, from the specified origin point to the sector departure point (see below), including threat zone avoidance taking into account the sector's limitations.
+The sector departure point is the start point of the specified exit route - if it is inside the sector, otherwise it is the closest point to it on the sector's perimeter.
+b. If the start point of the exit route is not inside the sector - a linking segment connecting the sector departure point to the start point of the specified exit route.
+c. The specified exit route (geometry).
+606
+Exit route (geometry)
+607
+Origin
+608
+Exit path
+609
+Path leading out of the specified containing sector, from the specified origin point (should be inside the containing sector) through the actual exit route (see below) of the specified containing sector, while avoiding threat zones inside the sector (meaning no threat zone avoidance on the exit route).
+The actual exit route is the specified exit route (geometry) - if it is not empty, otherwise - the preferred exit route of the specified containing sector.
+If the specified containing sector is empty or the actual exit route is empty - the returned path degenerates to only the origin point.
+610
+Origin point
+611
+Path exit point from sector
+612
+The exit point of the specified path from a sector applicable to the platform type and army of the specified formation.
+If the path does not start inside a sector - the start point of the specified path is returned.
+613
+Points are in the same sector
+614
+Are coordinate 1 and coordinate 2 both in the same sector.
+The check only refers to sectors associated with the specified platform category and army.
+615
+Coordinate 1
+616
+Coordinate 2
+617
+Platform category
+618
+Army
+619
+Containing sector polygon
+620
+The polygon of the sector (according to the applicable road network for the specified formation) containing the specified coordinate.
+621
+Air path is intra-sectoral
+622
+Is the specified air path entirely in the same sector.
+The check refers to sectors associated with the platform category and army of the specified formation.
+623
+Air path
+624
+The distance (in miles) to enter into a sector from a point on its perimeter, in order to reach a point that will be considered to be inside the sector for sure (to avoid accuracy problems in geometric calculations).
+625
+Chained air path
+626
+An air path composed of a concatenation of three segments:
+
+a. An origin path, which starts at the origin point and may be an exit path from an origin point located inside a sector or a path degenerated to only the origin point (if it is not inside a sector). The origin path already includes threat zone avoidance.
+
+b. A linking path, which is an optimal air path (taking into account the road network) from the end of the origin path to the beginning of the target path, including threat zone avoidance.
+
+c. A target path, which ends at the target point and may be an entry path leading to a target point located inside a sector or a path degenerated to only the target point (if it is not inside a sector). The target path also already includes threat zone avoidance.
+627
+Origin path
+628
+Takeoff
+629
+Target path
+630
+Landing
+631
+Air path within a bounded area
+632
+An air path leading from an origin point to a target point that are both inside the same bounded area (in practice: a sector or an area), while avoiding threat zones if necessary (if the formation considers threat zones).
+In this case, there is no need to consider traffic routes ("the road network") and in particular also not base access/departure routes.
+633
+Bounded area
+634
+Air path considering sectors
+635
+An optimal air path leading from the origin point to the target point, based on the traffic routes ("the road network") applicable to the specified platform category and army. The path takes into account entry and exit constraints from sectors.
+The implementation is based on the fact that the entry and exit constraint from sectors overrides the constraint of using base departure and access routes. This means that in the case of a base located inside a sector, the resulting path leads directly to/from the base from/to the sector's entry/exit route, ignoring the base's departure/access routes.
+636
+Exit from sector segment avoiding threat zones
+637
+An air path avoiding threat zones based on the exit from sector segment from the specified existing path - from its beginning to the specified exit from sector point. If the specified exit from sector point is equal to the start point of the specified existing path - the returned path is degenerated to only the start point of the existing path.
+638
+Existing path
+639
+Exit point from the sector
+640
+Entry to sector segment avoiding threat zones
+641
+An air path avoiding threat zones based on the entry to sector segment from the specified existing path - from the specified entry to sector point to its end. If the specified entry to sector point is equal to the end point of the specified existing path - the returned path is degenerated to only the end point of the existing path.
+642
+Entry point to the sector
+643
+External to sectors segment avoiding threat zones
+644
+An air path avoiding threat zones based on an external to sectors segment from the specified existing path, which starts at the specified exit from sector point and ends at the specified entry to sector point.
+645
+Exit point from sector
+646
+Chained air path avoiding threat zones
+647
+An air path avoiding threat zones based on the specified existing path and intended for the specified formation.
+The existing path is composed of three segments, each of which is handled separately:
+
+- An exit from sector segment, which starts at the beginning of the existing path and ends at the specified exit from sector point. If the existing path does not start in a sector - the specified exit from sector point is the start point of the existing path so that this segment is reduced to a point.
+
+- An external to sectors segment, which starts at the specified exit from sector point and ends at the specified entry to sector point.
+
+- An entry to sector segment, which starts at the specified entry to sector point and ends at the end point of the existing path. If the existing path does not end in a sector - the specified entry to sector point is the end point of the existing path, so that this segment is reduced to a point.
+648
+Air path crossing sectors avoiding threat zones
+649
+An air path avoiding threat zones based on the specified existing path and intended for the specified formation.
+The threat zone avoidance is based on the assumption that the existing path may start in a sector and/or end in a sector and it necessarily includes a "free" flight segment - external to any sector.
+650
+Intra-sectoral air path avoiding threat zones
+651
+An air path avoiding threat zones based on the specified existing path and intended for the specified formation.
+The threat zone avoidance is based on the assumption that the existing path is entirely within the same sector.
+652
+Threat zone avoidance for an existing path
+653
+An air path avoiding threat zones and with rounded turns according to the specified turning radius, based on the specified existing path and intended for the specified formation. The returned path also includes an intercept segment suitable for a formation located at the beginning of the existing path and in the direction of its first leg.
+The threat zone avoidance refers to the possibility that the specified existing path starts in a sector and/or ends in a sector.
+654
+Connecting segment to a straight air path avoiding threat zones
+655
+The segment on which a specified straight air path avoiding threat zones can be intercepted.
+The connection point must be at a distance greater than the minimum start range from the focus point, and at a distance greater than the minimum path length from the end of the path.
+656
+Straight air path
+657
+Focus point
+658
+Minimum path length
+659
+Minimum start range
+660
+Intercept path to a straight air path avoiding threat zones
+661
+An intercept path leading from the origin point and origin direction to the closest point on the specified connecting air segment avoiding threat zones.
+662
+Origin direction
+663
+Sector boundaries
+664
+Straight air path avoiding threat zones of optimal length
+665
+An optimal (minimum length) air path avoiding threat zones, based on the specified base path and intercept path.
+666
+Intercept path
+667
+Maximum end range
+668
+Air path avoiding threat zones
+669
+An air path intended for the specified formation, based on the specified suspect path, where segments passing through a threat zone are replaced if possible by bypass segments - if the formation considers threat zones. The returned path may contain transit segments in a threat zone that cannot be bypassed, in particular (but not only) when the start/end point is inside a threat zone.
+If the specified sector boundaries are empty - there is no restriction on the location of the bypass segments. Non-empty sector boundaries affect the choice of bypass segments as follows:
+- If the suspect path is entirely within the sector boundaries - the bypass segments must also be within the sector boundaries.
+- If the suspect path is not entirely within the sector boundaries - there is a preference for shortening the part of the bypass segments that passes outside the sector boundaries.
+670
+Suspect path
+671
+Conditional air path avoiding threat zones
+672
+An air path intended for the specified formation, based on the specified suspect path, where segments passing through a threat zone are replaced if possible by bypass segments, only if the specified "straight line" value is 'yes' or if the formation deviates from a sector to avoid a threat zone (as derived from the flight approval in a threat zone defined in the mission instructions). The returned path is rounded turns according to the specified turning radius (in nautical miles).
+
+Explanation: If flying in a straight line - the specified "suspect path" is a straight line on which no threat zone avoidance logic has been applied at all, and therefore it must be applied here. Otherwise - the threat zone avoidance logic has already been applied separately to each of the three segments of the "suspect path" (exit from sector, linking, entry to sector), so that the "suspect path" does not violate the rules of entry and exit from sectors through entry/exit routes. In this case, an additional activation of the threat zone avoidance logic here - without reference to sectors, may cause a violation of the rules (entry/exit not through entry/exit routes) and therefore it is conditional on the policy dictated by the mission instructions.
+673
+Straight line
+674
+Whether to ignore traffic routes and rules of entry and exit from sectors.
+675
+Flight vector is on a path
+676
+The flight vector defined by the specified origin point and origin direction is considered to be on the specified path if the origin point is on the path (up to 1 meter from it) and the origin direction is equal (up to a "smooth turn angle") to the direction of the path at the origin point.
+677
+Conditional intercept path
+678
+An intercept path leading from the origin point and origin direction to the closest interceptable point on the target path, according to the specified turning radius.
+If the origin point is already on the target path and the direction of the target path at this point is equal to the origin direction - no interception is needed and therefore the returned path is degenerated to only the origin point.
+679
+Intercept path to a point
+680
+An intercept path leading from the origin point and origin direction to the target point in the specified target direction.
+681
+Target direction
+682
+Intercept path to the beginning
+683
+An intercept path leading from the origin point and origin direction to the beginning of the target path.
+684
+Air path including intercept
+685
+A flight path intended for a platform located at the specified origin point and origin direction and is supposed to fly on the specified path, while rounding turns according to the specified turning radius.
+If it is specified that a takeoff should be performed and the specified path starts at the origin point - the returned path is the specified path as is (interception is not relevant), otherwise the returned path is based on a concatenation of two segments:
+- The intercept path to the specified path - according to "conditional intercept path", or "intercept path to the beginning" if it is specified that the path should be intercepted from its beginning.
+- The remainder of the specified path - from the intercept point to its end.
+686
+Origin point
+687
+Formation is authorized to intercept a path directly
+688
+Is the specified formation authorized to intercept a path at the specified intercept target point, directly - i.e. without using an operational air path to reach the intercept target point. The answer is positive if all the following conditions are met:
+- The formation is in the air.
+- The formation's location is at the intercept target point (in practice up to 1 meter from it, to cover for accuracy problems) or that:
+    + The distance from the formation's location to the intercept target point does not exceed 5 miles and also
+    + The formation's location and the intercept target point are not inside a sector or the straight line connecting them is intra-sectoral.
+689
+Intercept target point
+690
+Number of points to approximate a circle - air
+691
+The number of points in a polyline used to approximate a complete turning circle (360 degrees), as derived from the "smooth turn angle" value.
+692
+Number of points to approximate an arc
+693
+The number of points in a polyline used to approximate a turning arc corresponding to the specified angle.
+694
+Angle
+695
+A path in the shape of an arc for a left turn at the specified turn rate, based on the specified turning radius (in miles). The path starts at the specified origin point and origin direction.
+696
+Turn rate
+697
+A path in the shape of an arc for a right turn at the specified turn rate, based on the specified turning radius (in miles). The path starts at the specified origin point and origin direction.
+698
+Complete turn path
+699
+A complete turning path - according to the specified turning radius, which starts at the specified origin point and origin direction and ends at the origin point in an azimuth opposite to the origin direction. The path is composed of the following parts:
+- A 90-degree turn to the left.
+- A 270-degree turn to the right.
+- A straight segment of twice the turning radius, up to the origin point.
+700
+Smooth turn angle
+701
+The turning angle that is considered smooth enough to approximate a turning arc (part of a circle) by a collection of chords (a run parameter).
+702
+If no value is specified for the "smooth turn angle" run parameter - 174 degrees is assumed, meaning 60 points for a complete turning circle.
+703
+Glued flight path
+704
+A "glued" path from the two specified paths, including rounding of turns according to the specified turning radius.
+If the end point of the first path is not identical to the start point of the second path, the returned path includes the linking segment (straight line) between them.
+705
+Path 1
+706
+Path 2
+707
+Operational air path from a given vector
+708
+An operational air path intended for the arrival of the specified formation from a given flight vector (the specified origin point and origin direction) to the specified target, taking into account the following factors:
+- Use of traffic routes ("the road network") and consideration of entry and exit rules from sectors, unless it is specified to fly in a straight line.
+- Flight restrictions in a threat zone (if applicable to the specified formation), taking into account the specified sector boundaries.
+- Rounding of turns according to the specified turning radius (in nautical miles).
+709
+The following algorithms are activated in a chain - each algorithm is activated on the result of the previous one:
+- Optimal flight path finding algorithm
+- Threat zone avoidance algorithm (if applicable)
+- Rounding of turns algorithm
+- Intercept path to path finding algorithm.
+710
+Operational air path from current vector
+711
+An operational air path intended for the arrival of the specified formation from its current flight vector to the specified target, taking into account the following factors:
+- Use of traffic routes ("the road network") and consideration of entry and exit rules from sectors, unless it is specified to fly in a straight line.
+- Flight restrictions in a threat zone (if applicable to the specified formation), taking into account the specified sector boundaries.
+- Rounding of turns according to the turning radius derived from the typical turn rate for the platform type of the specified formation and the specified speed (in knots).
+712
+Hippodrome-shaped air path
+713
+A circular path in the shape of a hippodrome ("popsicle stick") with the following properties:
+- It starts and ends at the specified "origin point".
+- The radius of its arcs is the specified "turning radius (nautical miles)".
+- Its straight leg is of the specified "straight segment length (nautical miles)" (may in particular be zero) and in the specified "origin direction" azimuth.
+- It starts with a right arc, i.e. the specified "origin point" is at the end of its left straight leg.
+714
+Straight segment length (nautical miles)
+715
+Outbound leg on a left air path
+716
+A circular path composed of:
+- The specified "base path".
+- A 180-degree turn to the left with the "turning radius (nautical miles)".
+- A parallel path to the left of the base path at a distance of 2 x turning radius.
+- A 180-degree turn to the left to the beginning of the base path.
+717
+Trimming 19 meters from the parallel path is intended to overcome an accuracy problem in its calculation.
+718
+Outbound leg on a right air path
+719
+A circular path composed of:
+- The specified "base path".
+- A 180-degree turn to the right with the "turning radius (nautical miles)".
+- A parallel path to the right of the base path at a distance of 2 x turning radius.
+- A 180-degree turn to the right to the beginning of the base path.
+720
+Trimming 19 meters from the parallel path is intended to overcome an accuracy problem in its calculation.
+721
+Outbound leg on an air path
+722
+The shorter of the "outbound leg on a right air path" and "outbound leg on a left path" for the specified "base path" and "turning radius (nautical miles)".
+723
+Complete turn at the end of an air path
+724
+A complete turning path with the specified turning radius that starts and ends at the end of the specified base path.
+725
+Out-and-back on an air path
+726
+A circular path composed of the following parts:
+- The specified base path.
+- A complete turning path at the end of the base path.
+- The reverse of the base path.
+- A complete turning path at the end of the reverse of the base path.
+727
+Circular orbit path
+728
+A circular path that orbits the specified "base path".
+The radius of the path's arcs is the specified "turning radius (nautical miles)".
+729
+Distance according to speed and time
+730
+The distance (in nautical miles) that can be traveled at the specified speed (knots) during the specified time.
+731
+Time
+732
+Speed according to distance and time
+733
+The speed (in knots) required to travel the specified distance (in nautical miles) during the specified time.
+734
+Time according to speed and distance
+735
+The time required to travel the specified distance (in nautical miles) at the specified speed (in knots).
+736
+Flight duration for a distance
+737
+The time that will be required to fly the specified distance in meters at the specified ground speed (in knots).
+738
+Distance in meters
+739
+Ground speed (knots)
+740
+Flight duration on a path
+741
+The time that will be required to fly on the specified path at the specified ground speed (in knots).
+742
+Flight time to a coordinate
+743
+The time that will be required for the specified formation to fly from its current location to the specified coordinate at the typical flight speed for its platform type, and to land if necessary.
+744
+Coordinate
+745
+A non-empty value means that these boundaries should be taken into account for threat zone avoidance.
+746
+Formation is authorized to enter threat zones
+747
+The specified formation is authorized to enter threat zones if its "applicable operation ID" value is empty or if the "flight approval in threat zone" value from its mission instructions is not "no entry to threat zone".
+748
+Formation deviates from sector to avoid a threat zone
+749
+The specified formation deviates from a sector to avoid a threat zone if the "flight approval in threat zone" value from its mission instructions is "no entry to threat zone".
+750
+Formation considers threat zones
+751
+A formation considers threat zones if its "applicable operation ID" value is not empty and also its "flight approval in threat zone" value is not "free flight in threat zone".
+752
+Air path crosses threat zones
+753
+A path is considered to cross threat zones if it passes through at least one threat zone relevant to the formation's "applicable operation ID".
+Does the specified air path pass through at least one threat zone relevant to the "applicable operation ID" of the specified formation.
+754
+A base object located within a range of 500 meters from the specified coordinate.
+If there is no such object - an empty object value is returned.
+755
+The ID of a landing strip linked to the specified operation and located within a range of 500 meters from the specified coordinate.
+If there is no such one - an empty value is returned.
+756
+Operation ID
+757
+Actual landing location
+758
+The actual landing location of the specified formation is determined as follows:
+- If "landing coordinate" is specified - the "landing point" is this coordinate.
+- Otherwise if "landing strip" is specified - the "landing point" is this coordinate.
+- Otherwise if "landing base" is specified - the "landing point" is at the location of the specified "landing base".
+- Otherwise - the implied "landing point" is the "first takeoff point" (as stored in memory by a scheduled flight along a path command).
+759
+The closest usable airbase to the formation
+760
+The closest airbase to the specified formation that meets all the following conditions:
+- Its maximum runway length is not shorter than the required runway length (tactical function) by the formation.
+- It has the same military affiliation as the formation.
+- It is at a distance not exceeding the specified maximum range from the current location of the formation.
+761
+Maximum range (nautical miles)
+762
+Nearby usable takeoff/landing base
+763
+A usable airbase within a range of up to 1/2 mile from the formation's location. If there is no such one - an empty value is returned.
+764
+Nearby takeoff/landing landing strip ID
+765
+The ID of the landing strip near the formation.
+If no nearby landing strip linked to the applicable operation for the formation is found - an empty value is returned.
+766
+Retrieve the "send takeoff report (C2)" value from the permanent memory of the specified formation.
+767
+Base usable by a formation
+768
+The specified base is considered usable (takeoff/landing) by the specified air unit if its maximum runway length is not shorter than the required runway length (tactical function) by the formation.
+769
+Base

--- a/hebrew/translated/Mamraz Doctrine - Airforce Splits_dictionary_heb.txt
+++ b/hebrew/translated/Mamraz Doctrine - Airforce Splits_dictionary_heb.txt
@@ -1,0 +1,271 @@
+1
+Split formation (implementation)
+2
+Splitting the formation, including handling the possible alternatives for the behavior of the new (splitting) formation:
+- Arrival at a target coordinate in the air and/or self-destruction
+- Flight to landing.
+3
+Number of splitting aircraft
+4
+The number of aircraft splitting from the formation.
+5
+Target coordinate in the air
+6
+If specified - arrival at this coordinate should be performed.
+7
+Destruction in the air
+8
+Whether to perform self-destruction in the air.
+9
+Straight line to target
+10
+Whether to fly to the target (coordinate in the air or landing point) in a straight line, ignoring traffic route constraints.
+11
+Land at a nearby base
+12
+If a 'yes' value is specified - landing will be performed at the nearest base.
+13
+Landing base
+14
+If specified - landing will be performed at this base.
+15
+Landing strip
+16
+If specified - landing will be performed at this landing strip.
+17
+Landing coordinate
+18
+If specified - landing will be performed at this coordinate (for helicopters only).
+19
+1. Perform "split ammunition group" with "number of leavers" equal to the specified "number of splitting aircraft", for the purpose of "birthing" a new formation. For the avoidance of doubt: the new formation is not linked to a mission order.
+
+2. Send a "post-split execution order" event to the new formation.
+
+3. Perform "change suffix to name" to "call sign numbering", equal to the series of digits from L to L+N-1 (for example: "Nimrod12") where:
+- L is the "leader number" (tactical function)
+- N is the number of remaining aircraft (the initial number of aircraft minus the number of splitting aircraft, in the example: 2).
+
+4. Perform "send message" (self) of type "warning without handling": "[number of splitting aircraft] aircraft have split from [name of the original formation]".
+20
+Entire unit
+21
+The ammunition group split has ended
+22
+Leader number
+23
+Number of remaining aircraft
+24
+Call sign numbering
+25
+The formation has split:
+26
+One aircraft has abandoned.
+27
+One aircraft has left.
+28
+have left.
+29
+Executing instructions after a split
+30
+The original formation
+31
+1. Set the "leader number" (hereinafter L) to the "leader number" (tactical function) of the original formation plus the number of aircraft (current, after the split) in the original formation.
+
+2. Perform the following commands:
+
+a. "Change suffix to name" to "call sign numbering", equal to the series of digits from L to L+N-1 (for example: "Nimrod34") where:
+- L is the "leader number" (tactical function) of the original formation plus the number of aircraft in the original formation (in the example: 2)
+- N is the number of aircraft in the executing formation (in the example: 2).
+
+b. "Set timing instructions (atomic)" and "Set mission instructions (atomic)" with the corresponding parameter values in the original formation.
+
+c. "Set transmission status" with the corresponding parameter values in the original formation.
+
+d. "Set mission execution state" with:
+- Execution state - "en route".
+- Note for execution state - "after split.".
+
+3. Remember "original operation ID" equal to the "applicable operation ID" (tactical function) of the original formation.
+    Remember "original executed mission order ID" equal to the "applicable executed mission order ID" (tactical function) of the original formation.
+
+4. Remember "first takeoff point" (see tactical function with this name) equal to the "first takeoff point" of the original formation.
+
+5. Perform "send message" (self) of type "warning without handling": "The formation has split from [name of the original formation]".
+
+6. Perform "flight along a path (atomic)" with:
+ - "Path" starting at the current location of the original formation, of "path length before separation" and in the current [flight] direction of the original formation + "separation angle".
+ - "Initial speed" equal to the current speed of the original formation.
+ - "Initial altitude" equal to the current altitude of the original formation.
+
+7. If there is a need to fly to a target in the air (a "target in the air" coordinate was specified and also self-destruction should not be performed) - perform "arrival at coordinate" with:
+- Coordinate - the specified "target coordinate in the air"
+- Arrival time - empty
+- Wait on arrival - 'no'
+- Straight line to coordinate - the specified "straight line to target".
+
+8. If self-destruction should be performed - perform "abandonment (implementation)" with the specified "target coordinate in the air" and "straight line to target" values.
+
+9. If there is a need to land - perform "flight to landing" with
+- Straight line to landing - the specified "straight line to target"
+- Landing base - the actual landing base (the specified landing base or the closest base to the formation - if "land at nearby base" was specified).
+- Landing strip - as specified
+- Landing coordinate - as specified.
+32
+After split.
+33
+Maximum range for nearby landing base (nautical miles)
+34
+Short path length before separation
+35
+Long path length before separation
+36
+Separation angle
+37
+Leader number of the original formation
+38
+Number of aircraft in the original formation
+39
+Number of aircraft in the splitting formation
+40
+The formation has split from
+41
+Self-destruction should be performed
+42
+Should fly to a target in the air
+43
+Should land
+44
+Origin point
+45
+Origin direction
+46
+Path before split
+47
+The closest usable airbase
+48
+Actual landing base
+49
+Abandonment (implementation)
+50
+Abandonment of a single aircraft.
+51
+Abandonment coordinate
+52
+If specified - the abandoning aircraft will fly to this coordinate and the abandonment will be performed after arrival, otherwise - the abandonment will be performed immediately.
+53
+Straight line to abandonment
+54
+Whether to fly to the abandonment coordinate in a straight line, ignoring traffic route constraints.
+55
+1. If an abandonment coordinate is specified - perform "arrival at coordinate" with:
+- Coordinate - the specified "abandonment coordinate"
+- Arrival time - empty
+- Wait on arrival - 'no'
+- Straight line to coordinate - the specified "straight line to abandonment".
+
+2. Perform "set mission execution state" with execution state - "abandonment".
+
+3. Send an "information without handling" message with the text "abandonment".
+
+4. Perform "destroy ammunition group".
+56
+Abandonment
+57
+Should fly to abandonment coordinate
+58
+Post-split execution order
+59
+This event is sent by the original formation to the formation that split from it, immediately after the split. The event defines the required execution from the splitting formation.
+60
+Abandonment order
+61
+This event is sent by a formation with a single aircraft that is performing an abandonment. The event defines the required execution from the abandoning formation.
+62
+Response to post-split execution order
+63
+In response to receiving a "post-split execution order" event from the original formation, the new formation (that was "born" as part of the split) executes the order.
+64
+Response to abandonment order
+65
+In response to receiving an "abandonment order" event, the formation executes the order.
+66
+Split formation
+67
+Splitting the formation, including the option to define a target coordinate along which the splitting aircraft will fly.
+68
+Split formation "total number of aircraft"/"number of splitting aircraft"
+69
+Split formation
+70
+Must be greater than zero and strictly less than the number of aircraft in the formation
+71
+Target coordinate for splitting aircraft
+72
+The splitting aircraft will fly to this coordinate.
+73
+Perform split formation (implementation) with the specified parameters.
+74
+Emergency split
+75
+Splitting the formation with the option to specify a split path along which the splitting part will fly and a landing point to which the splitting aircraft will fly - in a straight line or on traffic routes.
+76
+Emergency split "total number of aircraft"/"number of splitting aircraft" [straight line to][name of takeoff/landing site | nearby base]
+77
+Emergency split
+78
+straight line to
+79
+landing at
+80
+nearby base
+81
+Straight line to landing
+82
+Whether to fly to land in a straight line, ignoring traffic route constraints.
+83
+"Land at nearby base" cannot be specified and also a landing base/landing strip/coordinate can be defined.
+84
+"Land at nearby base" or an explicit landing base/landing strip/coordinate must be specified
+85
+At most one landing parameter can be specified
+86
+Landing at a coordinate is possible for helicopters only.
+87
+Perform split formation (implementation) with the specified parameters.
+88
+Split formation (implementation)
+89
+Abandonment of a single aircraft.
+90
+Abandonment [at[straight line to]coordinate | immediate]
+91
+Abandonment
+92
+immediate
+93
+coordinate
+94
+If the formation has more than one aircraft - perform split formation (implementation) with the specified parameters.
+Otherwise - send an "abandonment order" event with the specified parameters.
+95
+Split formation (implementation).
+96
+The formation contains more than one aircraft
+97
+Number of aircraft
+98
+Single aircraft
+99
+Digit character
+100
+Returns the digit character at the index position in the aircraft numbering sequence in the call sign.
+101
+Start of sequence
+102
+End of sequence
+103
+Index
+104
+Call sign numbering sequence
+105
+Returns a numbering sequence for the call sign of a split formation.

--- a/hebrew/translated/Mamraz Doctrine - Airforce Testing_dictionary_heb.txt
+++ b/hebrew/translated/Mamraz Doctrine - Airforce Testing_dictionary_heb.txt
@@ -1,0 +1,45 @@
+1
+Simulate flight plan
+2
+Simulation of a flight plan containing the following commands:
+- Arrival at the starting point of the specified flight path
+- Holding pattern in the air for two minutes
+- Flight along the specified flight path
+- Holding pattern in the air for two minutes
+- Flight to landing at the specified landing coordinate.
+
+The plan includes a planning record containing flight paths, regular timing cards, an anchor timing card, and delivery arrows.
+3
+Flight path
+4
+Landing base
+5
+A base that can be used by the formation (with sufficient runway length) must be entered
+6
+Entire unit
+7
+Path to the beginning of the flight path
+8
+Path to landing
+9
+The entered flight path
+10
+Takeoff
+11
+Stabilization
+12
+Mag 456 (b)
+13
+K 7263 (a-1)
+14
+End
+15
+Landing
+16
+Test displaying bingo question
+17
+Display a bingo question with three possible answers to the user. The value of the selected answer should be received in a permanent memory note, whose value can be examined using a debug panel.
+18
+Display bingo question
+19
+What to do?

--- a/hebrew/translated/Mamraz Doctrine - C4I_dictionary_heb.txt
+++ b/hebrew/translated/Mamraz Doctrine - C4I_dictionary_heb.txt
@@ -1,0 +1,45 @@
+1
+Fire mission - indirect fire
+2
+Attack location
+3
+Ammunition allocation
+4
+Request ID
+5
+Unit to report
+6
+Target type
+7
+Observing unit
+9
+1. The ammunition type exists for the unit
+2. The target's coordinate is within the ammunition's range
+10
+Last iteration
+11
+Fire mission - dedicated fire
+12
+Fire plans
+13
+Target units
+14
+Firing on infrastructure
+15
+Target ID
+16
+Update attack results of artillery fire - according to observation unit
+17
+Observation unit
+18
+End of fire mission
+19
+PGM fire
+20
+Target object
+21
+Ammunition type
+22
+Ammunition quantity
+23
+Firing time

--- a/hebrew/translated/Mamraz Doctrine - Company Drills - Minimal_dictionary_heb.txt
+++ b/hebrew/translated/Mamraz Doctrine - Company Drills - Minimal_dictionary_heb.txt
@@ -1,0 +1,46 @@
+1
+Arrival at a point on the determined route (company combat team)
+2
+Arrival of a company combat team at a target point on the previously determined route which is stored in the unit's memory, where the point is defined absolutely.
+During the movement, response rules are activated to handle the following events:
+- Encounters with enemy units.
+- Encounters with an obstacle on the movement route.
+3
+Command key
+4
+Target point (on the route)
+5
+Movement mode
+6
+On encounter
+7
+Passing through a built-up area
+8
+Movement on axes
+9
+Hide from enemy units
+10
+Movement style
+11
+Speed
+12
+The maximum speed out of the possible maximum based on the data (in kilometers per hour).
+13
+Entire unit
+14
+Arrival of a sub-unit at a point on the determined route.
+In case of an encounter with an enemy or an obstacle on the movement route, appropriate response rules are activated.
+15
+Under arrival at a point on the determined route (company combat team)
+16
+Does the specified ammunition group participate in the execution of the "arrival at a point on the determined route (company combat team)" command by its commanding company.
+17
+Ammunition group
+18
+All the following conditions are met:
+- The commanding company is executing an arrival at a point on the determined route (company combat team) command.
+- The ammunition group is executing a movement in formation command, with a command key Kj.
+- The commanding company is executing a movement in formation command with the same command key Kj.
+19
+Explanation: The commanding company may be handling the execution of several movement in formation commands in parallel - one active and the rest temporarily suspended. For each of them, a different command key Ki for the job Ki is stored in the company.
+The ammunition group, on the other hand, may participate in the execution of at most one movement in formation command.

--- a/hebrew/translated/Mamraz Doctrine - Massua_dictionary_heb.txt
+++ b/hebrew/translated/Mamraz Doctrine - Massua_dictionary_heb.txt
@@ -1,0 +1,45 @@
+1
+Fire mission - indirect fire
+2
+Attack location
+3
+Ammunition allocation
+4
+Request ID
+5
+Unit to report
+6
+Target type
+7
+Observing unit
+9
+1. The ammunition type exists for the unit
+2. The target's coordinate is within the ammunition's range
+10
+Last iteration
+11
+Fire mission - dedicated fire
+12
+Fire plans
+13
+Target units
+14
+Firing on infrastructure
+15
+Target ID
+16
+Update attack results of artillery fire - according to observation unit
+17
+Observation unit
+18
+End of fire mission
+19
+PGM fire
+20
+Target object
+21
+Ammunition type
+22
+Ammunition quantity
+23
+Firing time

--- a/hebrew/translated/Mamraz Doctrine - Standby_dictionary_heb.txt
+++ b/hebrew/translated/Mamraz Doctrine - Standby_dictionary_heb.txt
@@ -1,0 +1,18 @@
+1
+Waiting for command
+2
+Waiting for a new command. This command is automatically added to a manual plan in which all commands have been completed, so that the plan will always contain an active command.
+3
+Waiting [in the air | on the ground] for a command
+4
+Waiting
+5
+in the air
+6
+on the ground
+7
+for a command
+8
+Entire unit
+9
+The formation is in the air

--- a/hebrew/translated/Mamraz Language DRY_dictionary_heb.txt
+++ b/hebrew/translated/Mamraz Language DRY_dictionary_heb.txt
@@ -1,0 +1,4 @@
+4
+Entire Unit
+12
+Must be positive


### PR DESCRIPTION
This change translates all the Hebrew dictionary files in the `./hebrew/` directory to English. The translated files are stored in the `./hebrew/translated/` directory with the same filenames.

The translation was done carefully, preserving the structure of the original files and keeping the military air-force context in mind, as requested. The special term "מבנה" was translated as "formation".

A total of 38 files were translated.